### PR TITLE
Add GitConnector service

### DIFF
--- a/packages/core/src/Core/ConnectorsService.ts
+++ b/packages/core/src/Core/ConnectorsService.ts
@@ -18,6 +18,7 @@ import { ManagedVaultConnector } from '@sre/Security/ManagedVault.service/Manage
 import { LogConnector } from '@sre/IO/Log.service/LogConnector';
 import { ComponentConnector } from '@sre/AgentManager/Component.service/ComponentConnector';
 import { ModelsProviderConnector } from '@sre/LLMManager/ModelsProvider.service/ModelsProviderConnector';
+import { GitConnector } from '@sre/IO/Git.service/GitConnector';
 const console = Logger('ConnectorService');
 
 let ServiceRegistry: TServiceRegistry = {};
@@ -185,6 +186,10 @@ export class ConnectorService {
 
     static getCodeConnector(name?: string): RouterConnector {
         return ConnectorService.getInstance<RouterConnector>(TConnectorService.Code, name);
+    }
+
+    static getGitConnector(name?: string): GitConnector {
+        return ConnectorService.getInstance<GitConnector>(TConnectorService.Git, name);
     }
 }
 

--- a/packages/core/src/Core/boot.ts
+++ b/packages/core/src/Core/boot.ts
@@ -16,6 +16,7 @@ import { LogService } from '@sre/IO/Log.service';
 import { ComponentService } from '@sre/AgentManager/Component.service';
 import { ModelsProviderService } from '@sre/LLMManager/ModelsProvider.service';
 import { CodeService } from '@sre/ComputeManager/Code.service';
+import { GitService } from '@sre/IO/Git.service';
 const console = Logger('Boot');
 let _booted = false;
 export function boot() {
@@ -42,6 +43,7 @@ export function boot() {
     service.Log = new LogService();
     service.Component = new ComponentService();
     service.Code = new CodeService();
+    service.Git = new GitService();
 
     SystemEvents.on('SRE:Initialized', () => {
         console.debug('SRE Initialized');

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -124,6 +124,8 @@ export * from './subsystems/IO/Router.service/RouterConnector';
 export * from './subsystems/IO/Storage.service/index';
 export * from './subsystems/IO/Storage.service/SmythFS.class';
 export * from './subsystems/IO/Storage.service/StorageConnector';
+export * from './subsystems/IO/Git.service/index';
+export * from './subsystems/IO/Git.service/GitConnector';
 export * from './subsystems/IO/VectorDB.service/index';
 export * from './subsystems/IO/VectorDB.service/VectorDBConnector';
 export * from './subsystems/LLMManager/LLM.service/index';

--- a/packages/core/src/subsystems/IO/Git.service/GitConnector.ts
+++ b/packages/core/src/subsystems/IO/Git.service/GitConnector.ts
@@ -1,0 +1,37 @@
+import { Connector } from '@sre/Core/Connector.class';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+export interface IGitRequest {
+    clone(repo: string, path: string): Promise<void>;
+    diff(repoPath: string, options?: string): Promise<string>;
+    commit(repoPath: string, message: string): Promise<void>;
+}
+
+export class GitConnector extends Connector {
+    public name = 'Git';
+
+    public async clone(repo: string, path: string) {
+        await execAsync(`git clone ${repo} ${path}`);
+    }
+
+    public async diff(repoPath: string, options = '') {
+        const { stdout } = await execAsync(`git -C ${repoPath} diff ${options}`);
+        return stdout;
+    }
+
+    public async commit(repoPath: string, message: string) {
+        await execAsync(`git -C ${repoPath} add .`);
+        await execAsync(`git -C ${repoPath} commit -m "${message.replace(/"/g, '\\"')}"`);
+    }
+
+    public requester(): IGitRequest {
+        return {
+            clone: this.clone.bind(this),
+            diff: this.diff.bind(this),
+            commit: this.commit.bind(this),
+        };
+    }
+}

--- a/packages/core/src/subsystems/IO/Git.service/index.ts
+++ b/packages/core/src/subsystems/IO/Git.service/index.ts
@@ -1,0 +1,9 @@
+import { ConnectorService, ConnectorServiceProvider } from '@sre/Core/ConnectorsService';
+import { TConnectorService } from '@sre/types/SRE.types';
+import { GitConnector } from './GitConnector';
+
+export class GitService extends ConnectorServiceProvider {
+    public register() {
+        ConnectorService.register(TConnectorService.Git, 'Git', GitConnector);
+    }
+}

--- a/packages/core/src/types/SRE.types.ts
+++ b/packages/core/src/types/SRE.types.ts
@@ -13,6 +13,7 @@ import { LogService } from '@sre/IO/Log.service';
 import { ComponentService } from '@sre/AgentManager/Component.service';
 import { ModelsProviderService } from '@sre/LLMManager/ModelsProvider.service';
 import { CodeService } from '@sre/ComputeManager/Code.service';
+import { GitService } from '@sre/IO/Git.service';
 
 export type TServiceRegistry = {
     Storage?: StorageService;
@@ -30,6 +31,7 @@ export type TServiceRegistry = {
     Component?: ComponentService;
     ModelsProvider?: ModelsProviderService;
     Code?: CodeService;
+    Git?: GitService;
 };
 
 export enum TConnectorService {
@@ -48,6 +50,7 @@ export enum TConnectorService {
     Component = 'Component',
     ModelsProvider = 'ModelsProvider',
     Code = 'Code',
+    Git = 'Git',
 }
 
 export type SREConnectorConfig = {

--- a/packages/core/tests/unit/git/git.test.ts
+++ b/packages/core/tests/unit/git/git.test.ts
@@ -1,0 +1,36 @@
+import { Git } from '@smythos/sdk';
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { execSync } from 'child_process';
+
+function tempDir(prefix: string) {
+    return mkdtempSync(path.join(tmpdir(), prefix));
+}
+
+describe('Git Connector', () => {
+    it('clone modify commit cycle', async () => {
+        const repoSrc = tempDir('repo-src-');
+        execSync('git init', { cwd: repoSrc });
+        fs.writeFileSync(path.join(repoSrc, 'file.txt'), 'hello');
+        execSync('git add .', { cwd: repoSrc });
+        execSync('git commit -m "init"', { cwd: repoSrc });
+
+        const cloneDir = tempDir('repo-clone-');
+        const git = Git.instance();
+        await git.clone(repoSrc, cloneDir);
+
+        const filePath = path.join(cloneDir, 'file.txt');
+        fs.appendFileSync(filePath, ' world');
+
+        const diff = await git.diff(cloneDir);
+        expect(diff).toContain('world');
+
+        await git.commit(cloneDir, 'update');
+
+        const log = execSync('git log -1 --pretty=%B', { cwd: cloneDir }).toString().trim();
+        expect(log).toBe('update');
+    });
+});

--- a/packages/sdk/src/Git/Git.class.ts
+++ b/packages/sdk/src/Git/Git.class.ts
@@ -1,0 +1,7 @@
+import { GitInstance } from './GitInstance.class';
+
+export class Git {
+    static instance(settings?: any) {
+        return new GitInstance(settings);
+    }
+}

--- a/packages/sdk/src/Git/GitInstance.class.ts
+++ b/packages/sdk/src/Git/GitInstance.class.ts
@@ -1,0 +1,34 @@
+import { ConnectorService, TConnectorService, GitConnector } from '@smythos/sre';
+import { SDKObject } from '../Core/SDKObject.class';
+
+export class GitInstance extends SDKObject {
+    private connector: GitConnector;
+
+    constructor(private settings: any = {}) {
+        super();
+    }
+
+    protected async init() {
+        await super.init();
+        let git = ConnectorService.getGitConnector();
+        if (!git?.valid) {
+            git = ConnectorService.init(TConnectorService.Git, 'Git', 'Git', {});
+        }
+        this.connector = git.instance(this.settings);
+    }
+
+    async clone(repo: string, path: string) {
+        await this.ready;
+        await this.connector.clone(repo, path);
+    }
+
+    async diff(repoPath: string, options?: string) {
+        await this.ready;
+        return await this.connector.diff(repoPath, options);
+    }
+
+    async commit(repoPath: string, message: string) {
+        await this.ready;
+        await this.connector.commit(repoPath, message);
+    }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -31,6 +31,8 @@ export * from './utils/help';
 export * from './utils/index';
 export * from './VectorDB/VectorDB.class';
 export * from './VectorDB/VectorDBInstance.class';
+export * from './Git/Git.class';
+export * from './Git/GitInstance.class';
 export * from './Components/generated/APICall';
 export * from './Components/generated/APIOutput';
 export * from './Components/generated/Await';


### PR DESCRIPTION
## Summary
- add Git connector service with basic CLI wrappers
- register Git service at boot and connector service
- expose git utilities via SDK
- include unit test for a clone/modify/commit cycle

## Testing
- `pnpm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_6872ef2a272c832b9fe376afe457ceb8