### PR TITLE
Add HTTPCall and WebSearch components

### DIFF
--- a/packages/core/src/Components/HTTPCall.class.ts
+++ b/packages/core/src/Components/HTTPCall.class.ts
@@ -1,0 +1,57 @@
+import axios from 'axios';
+import Joi from 'joi';
+import { Component } from './Component.class';
+import { IAgent as Agent } from '@sre/types/Agent.types';
+
+export class HTTPCall extends Component {
+    protected configSchema = Joi.object({
+        method: Joi.string()
+            .valid('GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS')
+            .default('GET')
+            .label('Method'),
+        url: Joi.string().uri().required().label('URL'),
+        headers: Joi.any().optional().label('Headers'),
+        body: Joi.any().optional().label('Body'),
+        query: Joi.any().optional().label('Query'),
+    });
+
+    constructor() {
+        super();
+    }
+
+    init() {}
+
+    async process(input: any, config: any, agent: Agent) {
+        await super.process(input, config, agent);
+
+        const logger = this.createComponentLogger(agent, config);
+        try {
+            const method = (config?.data?.method || 'GET').toLowerCase();
+            const url = config?.data?.url;
+            const headers = config?.data?.headers || {};
+            const data = config?.data?.body;
+            const params = config?.data?.query;
+
+            logger.debug('HTTP Call request', { method, url, headers, params, data });
+
+            const response = await axios({ method, url, headers, params, data });
+
+            return {
+                Response: response.data,
+                Headers: response.headers,
+                Status: response.status,
+                _error: undefined,
+                _debug: logger.output,
+            };
+        } catch (err: any) {
+            logger.error('HTTP Call failed', err.message);
+            return {
+                Response: err?.response?.data,
+                Headers: err?.response?.headers,
+                Status: err?.response?.status,
+                _error: err?.message || err.toString(),
+                _debug: logger.output,
+            };
+        }
+    }
+}

--- a/packages/core/src/Components/WebSearch.class.ts
+++ b/packages/core/src/Components/WebSearch.class.ts
@@ -1,0 +1,83 @@
+import axios from 'axios';
+import Joi from 'joi';
+import { Component } from './Component.class';
+import { IAgent as Agent } from '@sre/types/Agent.types';
+
+export class WebSearch extends Component {
+    protected schema = {
+        name: 'WebSearch',
+        description: 'Use this component to perform a web search',
+        inputs: {
+            SearchQuery: {
+                type: 'Text',
+                description: 'The search query',
+                default: true,
+            },
+        },
+        outputs: {
+            Results: {
+                description: 'The search results',
+                default: true,
+            },
+        },
+    };
+
+    protected configSchema = Joi.object({
+        url: Joi.string().uri().default('https://api.duckduckgo.com/').label('URL'),
+        method: Joi.string().valid('GET', 'POST').default('GET').label('Method'),
+        headers: Joi.any().optional().label('Headers'),
+        body: Joi.any().optional().label('Body'),
+        query: Joi.any().optional().label('Query'),
+        queryParam: Joi.string().default('q').label('Query Param Name'),
+        format: Joi.string().default('json').label('Format'),
+    });
+
+    constructor() {
+        super();
+    }
+
+    init() {}
+
+    async process(input: any, config: any, agent: Agent) {
+        await super.process(input, config, agent);
+
+        const logger = this.createComponentLogger(agent, config);
+        try {
+            const method = (config?.data?.method || 'GET').toLowerCase();
+            const url = config?.data?.url;
+            const headers = config?.data?.headers || {};
+            const params: any = { ...(config?.data?.query || {}) };
+            const data = config?.data?.body;
+            const queryParam = config?.data?.queryParam || 'q';
+            const format = config?.data?.format || 'json';
+
+            if (input?.SearchQuery) {
+                params[queryParam] = input.SearchQuery;
+            }
+            if (format) {
+                params.format = format;
+            }
+
+            logger.debug('WebSearch request', { method, url, headers, params, data });
+
+            const response = await axios({ method, url, headers, params, data });
+
+            return {
+                Results: response.data,
+                Headers: response.headers,
+                Status: response.status,
+                _error: undefined,
+                _debug: logger.output,
+            };
+        } catch (err: any) {
+            logger.error('WebSearch failed', err.message);
+            return {
+                Results: err?.response?.data,
+                Headers: err?.response?.headers,
+                Status: err?.response?.status,
+                _error: err?.message || err.toString(),
+                _debug: logger.output,
+            };
+        }
+    }
+}

--- a/packages/core/src/Components/index.ts
+++ b/packages/core/src/Components/index.ts
@@ -3,6 +3,7 @@ import { APIEndpoint } from './APIEndpoint.class';
 import { APIOutput } from './APIOutput.class';
 import { PromptGenerator } from './PromptGenerator.class';
 import { APICall } from './APICall/APICall.class';
+import { HTTPCall } from './HTTPCall.class';
 import { VisionLLM } from './VisionLLM.class';
 import { FSleep } from './FSleep.class';
 import { FHash } from './FHash.class';
@@ -32,6 +33,7 @@ import { GenAILLM } from './GenAILLM.class';
 import { FileStore } from './FileStore.class';
 import { ScrapflyWebScrape } from './ScrapflyWebScrape.class';
 import { TavilyWebSearch } from './TavilyWebSearch.class';
+import { WebSearch } from './WebSearch.class';
 import { ComponentHost } from './ComponentHost.class';
 import { ServerlessCode } from './ServerlessCode.class';
 import { ImageGenerator } from './ImageGenerator.class'; // Legacy
@@ -46,6 +48,7 @@ const components = {
     PromptGenerator: new PromptGenerator(),
     LLMPrompt: new PromptGenerator(),
     APICall: new APICall(),
+    HTTPCall: new HTTPCall(),
     VisionLLM: new VisionLLM(),
     FSleep: new FSleep(),
     FHash: new FHash(),
@@ -73,7 +76,7 @@ const components = {
     MultimodalLLM: new MultimodalLLM(),
     GenAILLM: new GenAILLM(),
     FileStore: new FileStore(),
-    WebSearch: new TavilyWebSearch(),
+    WebSearch: new WebSearch(),
     WebScrape: new ScrapflyWebScrape(),
     TavilyWebSearch: new TavilyWebSearch(),
     ScrapflyWebScrape: new ScrapflyWebScrape(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -87,6 +87,8 @@ export * from './Components/APICall/parseHeaders';
 export * from './Components/APICall/parseProxy';
 export * from './Components/APICall/parseUrl';
 export * from './Components/Image/imageSettings.config';
+export * from './Components/HTTPCall.class';
+export * from './Components/WebSearch.class';
 export * from './subsystems/AgentManager/Agent.class';
 export * from './subsystems/AgentManager/Agent.helper';
 export * from './subsystems/AgentManager/AgentLogger.class';

--- a/packages/core/tests/unit/components/HTTPCall.test.ts
+++ b/packages/core/tests/unit/components/HTTPCall.test.ts
@@ -1,0 +1,53 @@
+import http from 'http';
+import { beforeAll, afterAll, describe, it, expect } from 'vitest';
+import { HTTPCall } from '../../../src/Components/HTTPCall.class';
+
+const agent: any = { id: 'agent', teamId: 'team', agentRuntime: { debug: false }, isKilled: () => false };
+
+let server: http.Server;
+let port: number;
+
+beforeAll(() => {
+    return new Promise((resolve) => {
+        server = http.createServer((req, res) => {
+            let body = '';
+            req.on('data', (chunk) => (body += chunk));
+            req.on('end', () => {
+                const response = {
+                    method: req.method,
+                    url: req.url,
+                    headers: req.headers,
+                    body: body ? JSON.parse(body) : undefined,
+                };
+                res.setHeader('Content-Type', 'application/json');
+                res.end(JSON.stringify(response));
+            });
+        }).listen(0, () => {
+            port = (server.address() as any).port;
+            resolve();
+        });
+    });
+});
+
+afterAll(() => new Promise((resolve) => server.close(resolve)));
+
+describe('HTTPCall Component', () => {
+    it('performs GET request with query', async () => {
+        const httpCall = new HTTPCall();
+        const config = { data: { method: 'GET', url: `http://localhost:${port}/test`, query: { foo: 'bar' }, headers: { 'X-Test': '1' } } };
+        const result = await httpCall.process({}, config, agent);
+        expect(result.Status).toBe(200);
+        expect(result.Response.method).toBe('GET');
+        expect(result.Response.url).toContain('foo=bar');
+        expect(result.Response.headers['x-test']).toBe('1');
+    });
+
+    it('performs POST request with body', async () => {
+        const httpCall = new HTTPCall();
+        const config = { data: { method: 'POST', url: `http://localhost:${port}/post`, body: { hello: 'world' } } };
+        const result = await httpCall.process({}, config, agent);
+        expect(result.Status).toBe(200);
+        expect(result.Response.method).toBe('POST');
+        expect(result.Response.body).toEqual({ hello: 'world' });
+    });
+});

--- a/packages/core/tests/unit/components/WebSearch.test.ts
+++ b/packages/core/tests/unit/components/WebSearch.test.ts
@@ -1,0 +1,36 @@
+import http from 'http';
+import { beforeAll, afterAll, describe, it, expect } from 'vitest';
+import { WebSearch } from '../../../src/Components/WebSearch.class';
+
+const agent: any = { id: 'agent', teamId: 'team', agentRuntime: { debug: false }, isKilled: () => false };
+
+let server: http.Server;
+let port: number;
+
+beforeAll(() => {
+    return new Promise((resolve) => {
+        server = http.createServer((req, res) => {
+            const url = new URL(req.url ?? '', `http://${req.headers.host}`);
+            const response = {
+                query: url.searchParams.get('q'),
+            };
+            res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify(response));
+        }).listen(0, () => {
+            port = (server.address() as any).port;
+            resolve();
+        });
+    });
+});
+
+afterAll(() => new Promise((resolve) => server.close(resolve)));
+
+describe('WebSearch Component', () => {
+    it('returns results for search query', async () => {
+        const webSearch = new WebSearch();
+        const config = { data: { url: `http://localhost:${port}/search` } };
+        const result = await webSearch.process({ SearchQuery: 'hello' }, config, agent);
+        expect(result.Status).toBe(200);
+        expect(result.Results.query).toBe('hello');
+    });
+});


### PR DESCRIPTION
## Summary
- implement `HTTPCall` and `WebSearch` components
- register components for runtime usage
- expose components in package exports
- add unit tests using local HTTP server

## Testing
- `pnpm exec vitest run packages/core/tests/unit/components/HTTPCall.test.ts packages/core/tests/unit/components/WebSearch.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6872f1cf0f08832b96f81010e65bad26