### PR TITLE
Add debug logging connector and workflow utilities

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -74,6 +74,9 @@
             },
             "update": {
                 "description": "Update CLI and check for updates"
+            },
+            "workflow": {
+                "description": "Save and load workflows"
             }
         }
     },

--- a/packages/cli/rollup.config.js
+++ b/packages/cli/rollup.config.js
@@ -22,6 +22,8 @@ const config = {
         'commands/agent': 'src/commands/agent/agent.index.ts',
         'commands/create': 'src/commands/create/create.index.ts',
         'commands/update': 'src/commands/update.ts',
+        'commands/workflow/save': 'src/commands/workflow/save.ts',
+        'commands/workflow/load': 'src/commands/workflow/load.ts',
         'hooks/preparse': 'src/hooks/preparse.ts',
         help: 'src/help.ts',
     },
@@ -61,6 +63,8 @@ const zeroDepConfig = {
         'commands/agent': 'src/commands/agent/agent.index.ts',
         'commands/create': 'src/commands/create/create.index.ts',
         'commands/update': 'src/commands/update.ts',
+        'commands/workflow/save': 'src/commands/workflow/save.ts',
+        'commands/workflow/load': 'src/commands/workflow/load.ts',
         'hooks/preparse': 'src/hooks/preparse.ts',
     },
     output: {

--- a/packages/cli/src/commands/workflow/load.ts
+++ b/packages/cli/src/commands/workflow/load.ts
@@ -1,0 +1,16 @@
+import { Args, Command } from '@oclif/core';
+import { loadWorkflow } from '@smythos/sre/utils';
+
+export default class WorkflowLoad extends Command {
+    static override description = 'Load a workflow from file';
+
+    static override args = {
+        file: Args.string({ description: 'Workflow file', required: true }),
+    } as const;
+
+    async run(): Promise<void> {
+        const { args } = await this.parse(WorkflowLoad);
+        const agent = loadWorkflow(args.file);
+        this.log(`Loaded workflow for agent ${agent.data.name || agent.data.id}`);
+    }
+}

--- a/packages/cli/src/commands/workflow/save.ts
+++ b/packages/cli/src/commands/workflow/save.ts
@@ -1,0 +1,19 @@
+import { Args, Command } from '@oclif/core';
+import { Agent } from '@smythos/sdk';
+import { saveWorkflow } from '@smythos/sre/utils';
+
+export default class WorkflowSave extends Command {
+    static override description = 'Save an agent workflow to a file';
+
+    static override args = {
+        agent: Args.string({ description: 'Agent .smyth file', required: true }),
+        file: Args.string({ description: 'Destination file', required: true }),
+    } as const;
+
+    async run(): Promise<void> {
+        const { args } = await this.parse(WorkflowSave);
+        const agent = Agent.import(args.agent);
+        saveWorkflow(agent, args.file);
+        this.log(`Workflow saved to ${args.file}`);
+    }
+}

--- a/packages/core/src/subsystems/IO/Log.service/connectors/DebugLog.class.ts
+++ b/packages/core/src/subsystems/IO/Log.service/connectors/DebugLog.class.ts
@@ -1,0 +1,57 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { Logger } from '@sre/helpers/Log.helper';
+import { AccessRequest } from '@sre/Security/AccessControl/AccessRequest.class';
+import { ACL } from '@sre/Security/AccessControl/ACL.class';
+import { IAccessCandidate, TAccessLevel } from '@sre/types/ACL.types';
+import { LogConnector } from '../LogConnector';
+import { AgentCallLog } from '@sre/types/AgentLogger.types';
+
+const console = Logger('DebugLog');
+
+export class DebugLog extends LogConnector {
+    public name: string = 'DebugLog';
+    public id: string;
+
+    public getResourceACL(resourceId: string, candidate: IAccessCandidate): Promise<ACL> {
+        return Promise.resolve(new ACL().addAccess(candidate.role, candidate.id, TAccessLevel.Owner));
+    }
+
+    private getLogFile(agentId: string) {
+        const dir = path.join(os.homedir(), '.smyth', 'logs', agentId);
+        if (!fs.existsSync(dir)) {
+            fs.mkdirSync(dir, { recursive: true });
+        }
+        return path.join(dir, 'debug.jsonl');
+    }
+
+    protected async log(acRequest: AccessRequest, logData: AgentCallLog, callId?: string): Promise<any> {
+        try {
+            const file = this.getLogFile(acRequest.candidate.id);
+            const entry = {
+                timestamp: new Date().toISOString(),
+                callId,
+                ...logData,
+            };
+            fs.appendFileSync(file, JSON.stringify(entry) + '\n');
+        } catch (error) {
+            console.error('Failed to write debug log:', error);
+        }
+        return Promise.resolve();
+    }
+
+    protected async logTask(acRequest: AccessRequest, tasks: number, isUsingTestDomain: boolean): Promise<void> {
+        try {
+            const file = this.getLogFile(acRequest.candidate.id);
+            const entry = {
+                timestamp: new Date().toISOString(),
+                tasks,
+                isUsingTestDomain,
+            };
+            fs.appendFileSync(file, JSON.stringify(entry) + '\n');
+        } catch (error) {
+            console.error('Failed to write debug task log:', error);
+        }
+    }
+}

--- a/packages/core/src/subsystems/IO/Log.service/index.ts
+++ b/packages/core/src/subsystems/IO/Log.service/index.ts
@@ -3,11 +3,13 @@ import { TConnectorService } from '@sre/types/SRE.types';
 import { Logger } from '@sre/helpers/Log.helper';
 
 import { ConsoleLog } from './connectors/ConsoleLog.class';
+import { DebugLog } from './connectors/DebugLog.class';
 
 const console = Logger('LogService');
 
 export class LogService extends ConnectorServiceProvider {
     public register() {
         ConnectorService.register(TConnectorService.Log, 'ConsoleLog', ConsoleLog);
+        ConnectorService.register(TConnectorService.Log, 'DebugLog', DebugLog);
     }
 }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -10,3 +10,4 @@ export * from './numbers.utils';
 export * from './string.utils';
 export * from './url.utils';
 export * from './validation.utils';
+export * from './workflow.utils';

--- a/packages/core/src/utils/workflow.utils.ts
+++ b/packages/core/src/utils/workflow.utils.ts
@@ -1,0 +1,12 @@
+import fs from 'fs';
+import { Agent } from '../../../sdk/src/Agent/Agent.class';
+
+export function saveWorkflow(agent: Agent, file: string) {
+    const data = agent.export();
+    fs.writeFileSync(file, JSON.stringify(data, null, 2), 'utf8');
+}
+
+export function loadWorkflow(path: string): Agent {
+    const data = fs.readFileSync(path, 'utf8');
+    return Agent.import(JSON.parse(data));
+}

--- a/packages/core/tests/integration/log/debug-log.test.ts
+++ b/packages/core/tests/integration/log/debug-log.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { ConnectorService } from '@sre/Core/ConnectorsService';
+import { AccessCandidate } from '@sre/Security/AccessControl/AccessCandidate.class';
+import { setupSRE } from '../utils/sre';
+
+const agentId = 'test-agent';
+const logDir = path.join(os.homedir(), '.smyth', 'logs', agentId);
+
+beforeAll(() => {
+    if (fs.existsSync(logDir)) fs.rmSync(logDir, { recursive: true, force: true });
+    setupSRE({
+        Log: { Connector: 'DebugLog' },
+    });
+});
+
+describe('DebugLog Connector', () => {
+    it('creates log file when logging', async () => {
+        const logConnector = ConnectorService.getLogConnector();
+        await logConnector
+            .requester(AccessCandidate.agent(agentId))
+            .log({ sourceId: 's', componentId: 'c' });
+
+        const file = path.join(logDir, 'debug.jsonl');
+        expect(fs.existsSync(file)).toBe(true);
+        const content = fs.readFileSync(file, 'utf8').trim();
+        expect(content.length).toBeGreaterThan(0);
+    });
+});

--- a/packages/core/tests/integration/workflow.utils.test.ts
+++ b/packages/core/tests/integration/workflow.utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { Agent } from '../../../sdk/src/Agent/Agent.class';
+import { saveWorkflow, loadWorkflow } from '@sre/utils';
+import { testData } from '../utils/test-data-manager';
+
+const tempFile = path.join(testData.getBaseDir(), 'temp-workflow.smyth');
+
+afterAll(() => {
+    if (fs.existsSync(tempFile)) fs.unlinkSync(tempFile);
+});
+
+describe('Workflow utils', () => {
+    it('saves and loads workflow', () => {
+        const agent = Agent.import(testData.getDataPath('sre-echo-LLMPrompt.smyth'));
+        saveWorkflow(agent, tempFile);
+        expect(fs.existsSync(tempFile)).toBe(true);
+        const loaded = loadWorkflow(tempFile);
+        expect(loaded.data.name).toBe(agent.data.name);
+    });
+});

--- a/packages/sdk/src/Agent/Agent.class.ts
+++ b/packages/sdk/src/Agent/Agent.class.ts
@@ -742,4 +742,11 @@ export class Agent extends SDKObject {
         const instance = new MCP(this);
         return await instance.start({ transport, port });
     }
+
+    /**
+     * Export the agent workflow as a plain object
+     */
+    public export() {
+        return JSON.parse(JSON.stringify(this.data));
+    }
 }


### PR DESCRIPTION
## Summary
- implement `DebugLog` connector for persistent JSON line logs
- register `DebugLog` in Log service
- add workflow save/load utilities
- expose new `export()` method on Agent class
- add CLI commands for workflow persistence
- test DebugLog and workflow utilities

## Testing
- `pnpm test` *(fails: Cannot find package '@smythos/sdk' ...)*

------
https://chatgpt.com/codex/tasks/task_e_6872f96b7810832b8fc6d8be6911ae30