### PR TITLE
Update docs for environment variables

### DIFF
--- a/packages/sdk/docs/01-getting-started.md
+++ b/packages/sdk/docs/01-getting-started.md
@@ -5,6 +5,35 @@ Welcome to the SmythOS SDK! This guide will walk you through creating your very 
 The code in this guide is a more detailed version of the script found in [`examples/01-agent-code-skill/01-prompting.ts`](../../examples/01-agent-code-skill/01-prompting.ts).
 
 ## 1. Installation
+### Environment Configuration
+
+Before running the examples you'll need a few environment variables. Set your `OPENROUTER_API_KEY` so the SDK can make LLM requests and provide your Neon PostgreSQL credentials for the `NeonAccount` connector:
+
+```bash
+export OPENROUTER_API_KEY=your-openrouter-key
+export NEON_HOST=your-neon-host
+export NEON_USER=your-neon-user
+export NEON_PASSWORD=your-neon-password
+export NEON_DATABASE=your-database
+```
+
+If you load agents from `.smyth` files you can pass these settings when calling `Agent.import`:
+
+```typescript
+import { Agent } from '@smythos/sdk';
+
+const agent = await Agent.import('./agent.smyth', {
+    Account: {
+        Connector: 'NeonAccount',
+        Settings: {
+            host: process.env.NEON_HOST,
+            user: process.env.NEON_USER,
+            password: process.env.NEON_PASSWORD,
+            database: process.env.NEON_DATABASE,
+        },
+    },
+});
+```
 
 ### Method 1: Using the CLI (Recommended)
 


### PR DESCRIPTION
## Summary
- add environment configuration section to setup OPENROUTER_API_KEY and Neon database credentials
- show example usage of Agent.import with NeonAccount

## Testing
- `pnpm install`
- `pnpm test` *(fails: Please provide an API key for OpenRouter)*

------
https://chatgpt.com/codex/tasks/task_e_687304285718832b8d40906058db80cf