### PR TITLE
Add debug log and docker docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Check the [Examples](examples), [documentation](https://smythos.github.io/sre/sd
 
 **Note:** If you face an issue with the CLI or with your code, set environment variable LOG_LEVEL="debug" and run your code again. Then share the logs with us, it will help diagnose the problem.
 
+Additional instructions for enabling DebugLog output and configuring Docker-based code execution are available in the [configuration guide](packages/core/docs/configuration.md#debug-logging).
+
 ## Repository Structure
 
 This monorepo contains three main packages:

--- a/packages/core/docs/configuration.md
+++ b/packages/core/docs/configuration.md
@@ -84,3 +84,38 @@ The vault stores keys for different teams, but must have at least a "default" te
 ### config.json Structure
 
 (TBD)
+
+### Debug Logging
+
+To capture detailed debugging information for each agent, configure the Log service
+to use the `DebugLog` connector:
+
+```json
+{
+    "Log": { "Connector": "DebugLog" }
+}
+```
+
+Logs are written to `~/.smyth/logs/<agent-id>/debug.jsonl`. Each line is a JSON
+object containing the timestamp and execution details.
+
+### Docker Execution
+
+When the `Docker` connector is selected for the Code service, code snippets run
+inside a Docker container. The container image and execution timeout are
+specified in the Code configuration:
+
+```json
+{
+    "Code": {
+        "Connector": "Docker",
+        "Settings": {
+            "image": "python:3.12-slim",
+            "timeout": 10000
+        }
+    }
+}
+```
+
+The `image` field sets the Docker image used to execute the code, while
+`timeout` (in milliseconds) controls how long the container is allowed to run.


### PR DESCRIPTION
## Summary
- document how to enable `DebugLog` connector and where logs are stored
- show how to configure Docker execution image and timeout
- reference the new configuration sections from the README

## Testing
- `pnpm test` *(fails: vitest tests require remote resources and fail without API keys)*

------
https://chatgpt.com/codex/tasks/task_e_68730430a21c832baa35031e2a6d1962