### PR TITLE
Add JobQueue service

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -99,6 +99,7 @@ export * from './subsystems/AgentManager/AgentSSE.class';
 export * from './subsystems/AgentManager/EmbodimentSettings.class';
 export * from './subsystems/AgentManager/ForkedAgent.class';
 export * from './subsystems/AgentManager/OSResourceMonitor';
+export * from './subsystems/JobQueue.service';
 export * from './subsystems/LLMManager/custom-models';
 export * from './subsystems/LLMManager/LLM.helper';
 export * from './subsystems/LLMManager/LLM.inference';

--- a/packages/core/src/subsystems/JobQueue.service/index.ts
+++ b/packages/core/src/subsystems/JobQueue.service/index.ts
@@ -1,0 +1,51 @@
+import EventEmitter from 'events';
+
+export interface JobQueueItem {
+    workflowId: string;
+    inputs: Record<string, any>;
+    metadata?: Record<string, any>;
+}
+
+export interface JobProgressEvent {
+    workflowId: string;
+    status: 'queued' | 'processing' | 'completed' | 'failed';
+    metadata?: Record<string, any>;
+    error?: any;
+}
+
+export class JobQueue extends EventEmitter {
+    private queue: JobQueueItem[] = [];
+    private active = 0;
+
+    constructor(private processor: (item: JobQueueItem) => Promise<void>, private concurrency = 1) {
+        super();
+        if (this.concurrency < 1) this.concurrency = 1;
+    }
+
+    public enqueue(item: JobQueueItem) {
+        this.queue.push(item);
+        this.emitProgress(item, 'queued');
+        this.process();
+    }
+
+    private emitProgress(item: JobQueueItem, status: JobProgressEvent['status'], error?: any) {
+        const event: JobProgressEvent = { workflowId: item.workflowId, status, metadata: item.metadata };
+        if (error) event.error = error;
+        this.emit('progress', event);
+    }
+
+    private process() {
+        while (this.active < this.concurrency && this.queue.length > 0) {
+            const item = this.queue.shift() as JobQueueItem;
+            this.active++;
+            this.emitProgress(item, 'processing');
+            this.processor(item)
+                .then(() => this.emitProgress(item, 'completed'))
+                .catch((err) => this.emitProgress(item, 'failed', err))
+                .finally(() => {
+                    this.active--;
+                    this.process();
+                });
+        }
+    }
+}

--- a/packages/core/tests/unit/core/JobQueue.test.ts
+++ b/packages/core/tests/unit/core/JobQueue.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { JobQueue, JobQueueItem } from '../../../src/subsystems/JobQueue.service';
+
+function createProcessor(results: string[], delayMs = 0) {
+    return async (item: JobQueueItem) => {
+        if (delayMs) await new Promise((r) => setTimeout(r, delayMs));
+        results.push(item.workflowId);
+    };
+}
+
+describe('JobQueue', () => {
+    it('processes jobs sequentially', async () => {
+        const processed: string[] = [];
+        const q = new JobQueue(createProcessor(processed, 10), 1);
+        q.enqueue({ workflowId: 'a', inputs: {} });
+        q.enqueue({ workflowId: 'b', inputs: {} });
+        await new Promise((r) => setTimeout(r, 50));
+        expect(processed).toEqual(['a', 'b']);
+    });
+
+    it('respects concurrency limit', async () => {
+        const processed: string[] = [];
+        const q = new JobQueue(createProcessor(processed, 10), 2);
+        q.enqueue({ workflowId: 'a', inputs: {} });
+        q.enqueue({ workflowId: 'b', inputs: {} });
+        q.enqueue({ workflowId: 'c', inputs: {} });
+        await new Promise((r) => setTimeout(r, 50));
+        expect(processed.sort()).toEqual(['a', 'b', 'c'].sort());
+    });
+
+    it('emits progress events', async () => {
+        const events: string[] = [];
+        const q = new JobQueue(async () => {}, 1);
+        q.on('progress', (e) => events.push(e.status));
+        q.enqueue({ workflowId: 'x', inputs: {} });
+        await new Promise((r) => setTimeout(r, 10));
+        expect(events).toContain('queued');
+        expect(events).toContain('processing');
+        expect(events).toContain('completed');
+    });
+});


### PR DESCRIPTION
## Summary
- add JobQueue service for running workflow jobs with progress events
- export the new service from the library
- test JobQueue sequential processing, concurrency and event emission

## Testing
- `pnpm test:run` *(fails: Please provide an API key for OpenRouter)*

------
https://chatgpt.com/codex/tasks/task_e_6873a32cf360832badb6797377f00410