### PR TITLE
Move workflow utils to SDK

### DIFF
--- a/packages/cli/src/commands/workflow/load.ts
+++ b/packages/cli/src/commands/workflow/load.ts
@@ -1,5 +1,5 @@
 import { Args, Command } from '@oclif/core';
-import { loadWorkflow } from '@smythos/sre/utils';
+import { loadWorkflow } from '@smythos/sdk/utils';
 import fs from 'fs';
 import path from 'path';
 

--- a/packages/cli/src/commands/workflow/save.ts
+++ b/packages/cli/src/commands/workflow/save.ts
@@ -1,6 +1,6 @@
 import { Args, Command } from '@oclif/core';
 import { Agent } from '@smythos/sdk';
-import { saveWorkflow } from '@smythos/sre/utils';
+import { saveWorkflow } from '@smythos/sdk/utils';
 
 export default class WorkflowSave extends Command {
     static override description = 'Save an agent workflow to a file';

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -10,4 +10,3 @@ export * from './numbers.utils';
 export * from './string.utils';
 export * from './url.utils';
 export * from './validation.utils';
-export * from './workflow.utils';

--- a/packages/core/tests/integration/workflow.utils.test.ts
+++ b/packages/core/tests/integration/workflow.utils.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, afterAll } from 'vitest';
 import fs from 'fs';
 import path from 'path';
-import { Agent } from '../../../sdk/src/Agent/Agent.class';
-import { saveWorkflow, loadWorkflow } from '@sre/utils';
+import { Agent } from '@smythos/sdk';
+import { saveWorkflow, loadWorkflow } from '@smythos/sdk/utils';
 import { testData } from '../utils/test-data-manager';
 
 const tempFile = path.join(testData.getBaseDir(), 'temp-workflow.smyth');

--- a/packages/sdk/src/utils/index.d.ts
+++ b/packages/sdk/src/utils/index.d.ts
@@ -7,3 +7,4 @@ export declare class ControlledPromise<T> extends Promise<T> {
 }
 export * from './general.utils';
 export * from './console.utils';
+export * from './workflow.utils';

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -36,3 +36,4 @@ export class ControlledPromise<T> extends Promise<T> {
 
 export * from './general.utils';
 export * from './console.utils';
+export * from './workflow.utils';

--- a/packages/sdk/src/utils/workflow.utils.d.ts
+++ b/packages/sdk/src/utils/workflow.utils.d.ts
@@ -1,0 +1,3 @@
+import { Agent } from '../Agent/Agent.class';
+export declare function saveWorkflow(agent: Agent, file: string): void;
+export declare function loadWorkflow(path: string): Agent;

--- a/packages/sdk/src/utils/workflow.utils.ts
+++ b/packages/sdk/src/utils/workflow.utils.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { Agent } from '../../../sdk/src/Agent/Agent.class';
+import { Agent } from '../Agent/Agent.class';
 
 export function saveWorkflow(agent: Agent, file: string) {
     fs.writeFileSync(file, JSON.stringify(agent.export(), null, 2));


### PR DESCRIPTION
## Summary
- relocate workflow utility functions to the SDK package
- export workflow utils from the SDK util barrel
- update CLI commands to import workflow helpers from the SDK
- adjust integration tests to reference SDK utilities
- drop workflow utils from the core utils barrel

## Testing
- `pnpm build` *(fails: Transform failed with "await" can only be used inside an "async" function)*

------
https://chatgpt.com/codex/tasks/task_e_6874086d3e5c832bb1c766c5ca671e59