### PR TITLE
Expose SRE components endpoint

### DIFF
--- a/packages/studio-server/README.md
+++ b/packages/studio-server/README.md
@@ -1,0 +1,18 @@
+# SmythOS Studio Server
+
+This package exposes a lightweight Express server used by the SmythOS studio.
+
+## Running
+
+Start the development server:
+
+```bash
+pnpm --filter @smythos/studio-server dev
+```
+
+By default the server listens on port `3010`. Once running you can list the
+available components with:
+
+```bash
+curl http://localhost:3010/components
+```

--- a/packages/studio-server/src/index.ts
+++ b/packages/studio-server/src/index.ts
@@ -5,40 +5,45 @@ import path from 'path';
 import os from 'os';
 import { Agent } from '@smythos/sdk';
 import { startMcpServer } from '../../cli/src/commands/agent/mcp.cmd';
-// import { LocalComponentConnector } from '@sre/subsystems/AgentManager/Component.service/connectors/LocalComponentConnector.class';
-// import { AccessRequest } from '@sre/subsystems/Security/AccessControl/AccessRequest.class';
-// import { TAccessRole } from '@sre/types/ACL.types';
+import {
+  LocalComponentConnector,
+  ConnectorService,
+  AccessCandidate,
+} from '@smythos/sre';
 
 const WORKFLOWS_DIR = path.join(__dirname, '../workflows');
 
-async function init() {
+async function bootSRE() {
   // Initialize SRE using startMcpServer with a minimal agent
-  const dummyAgent = { version: '1.0', data: { id: 'init', components: [], connections: [] } };
+  const dummyAgent = {
+    version: '1.0',
+    data: { id: 'init', components: [], connections: [] },
+  };
   await startMcpServer(dummyAgent, 'stdio', 0, {});
 }
 
-init().catch((err) => console.error(err));
+async function main() {
+  await bootSRE();
 
-const app = express();
-app.use(cors());
-app.use(express.json());
+  const app = express();
+  app.use(cors());
+  app.use(express.json());
 
 app.get('/components', async (_req, res) => {
-  const componentsDir = path.resolve(__dirname, '../../core/src/Components');
-  const componentFiles = fs.readdirSync(componentsDir);
-
-  const componentDetails = componentFiles
-    .filter(file => file.endsWith('.class.ts'))
-    .map(file => {
-      const name = path.basename(file, '.class.ts');
-      return {
-        name,
-        description: `The ${name} component.`,
-        inputs: [], 
-      };
-    });
-
-  res.json(componentDetails);
+  try {
+    const connector = ConnectorService.getComponentConnector() as LocalComponentConnector;
+    const requester = connector.requester(AccessCandidate.agent('studio-server'));
+    const components = await requester.getAll();
+    const componentDetails = Object.entries(components).map(([name, instance]: [string, any]) => ({
+      name,
+      settings: instance.schema?.settings || {},
+      inputs: instance.schema?.inputs || {},
+    }));
+    res.json(componentDetails);
+  } catch (err: any) {
+    console.error('Failed to load components', err);
+    res.status(500).json({ error: 'failed to load components' });
+  }
 });
 
 app.get('/workflows', (_req, res) => {
@@ -92,3 +97,6 @@ const PORT = Number(process.env.PORT) || 3010;
 app.listen(PORT, () => {
   console.log(`Studio server listening on http://localhost:${PORT}`);
 });
+}
+
+main().catch(err => console.error(err));

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import ReactFlow, {
   Background,
   Controls,
@@ -15,6 +15,14 @@ const initialEdges: any[] = [];
 export default function App() {
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+  const [components, setComponents] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetch('/components')
+      .then((r) => r.json())
+      .then(setComponents)
+      .catch(console.error);
+  }, []);
 
   const addNode = () => {
     setNodes((nds) => [
@@ -35,6 +43,11 @@ export default function App() {
       <div style={{ display: 'flex', height: '100vh' }}>
         <div style={{ width: 150, borderRight: '1px solid #ccc', padding: 10 }}>
           <button onClick={addNode}>Add Node</button>
+          <ul>
+            {components.map((c) => (
+              <li key={c.name}>{c.name}</li>
+            ))}
+          </ul>
         </div>
         <div style={{ flexGrow: 1 }}>
           <ReactFlow


### PR DESCRIPTION
## Summary
- initialize SRE before starting Studio server
- serve components list from LocalComponentConnector
- fetch real component list in Studio UI
- document how to run the Studio server and query `/components`

## Testing
- `pnpm test:run` *(fails: "Transform failed" and module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_68740a551864832b9a5c62369bcef0d3