### PR TITLE
Implement dynamic component fetching in studio

### DIFF
--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -1,0 +1,11 @@
+# SmythOS Studio
+
+The Studio UI fetches available components from a running instance of the Studio Server. By default the server listens on `http://localhost:3010`.
+
+To start the server in development run:
+
+```bash
+pnpm --filter @smythos/studio-server dev
+```
+
+Once running the Studio will load components from `http://localhost:3010/components`.

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -17,11 +17,25 @@ export default function App() {
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
   const [components, setComponents] = useState<any[]>([]);
 
+  const fallbackComponents = [
+    { name: 'TextInput' },
+    { name: 'HTTPCall' },
+  ];
+
   useEffect(() => {
-    fetch('/components')
-      .then((r) => r.json())
-      .then(setComponents)
-      .catch(console.error);
+    async function loadComponents() {
+      try {
+        const res = await fetch('http://localhost:3010/components');
+        if (!res.ok) throw new Error(`Status ${res.status}`);
+        const data = await res.json();
+        setComponents(data);
+      } catch (err) {
+        console.error('Failed to fetch components, using fallback', err);
+        setComponents(fallbackComponents);
+      }
+    }
+
+    loadComponents();
   }, []);
 
   const addNode = () => {


### PR DESCRIPTION
## Summary
- fetch component list from local studio server with fallback data
- describe server URL in the studio README

## Testing
- `pnpm test` *(fails: Cannot find package '@smythos/sdk' and missing API key)*

------
https://chatgpt.com/codex/tasks/task_e_68741fe28f08832ba78e7be1f124bbc4