### PR TITLE
Implement workflow execution route

### DIFF
--- a/packages/studio-server/README.md
+++ b/packages/studio-server/README.md
@@ -16,3 +16,20 @@ available components with:
 ```bash
 curl http://localhost:3010/components
 ```
+
+## API
+
+### `POST /execute`
+
+Execute a workflow sent in the request body. The payload must include a
+`workflow` object matching the SmythOS agent schema and an optional `prompt`
+string. The server imports the workflow using `Agent.import`, runs it with the
+provided prompt and returns the result as JSON.
+
+Example request:
+
+```bash
+curl -X POST http://localhost:3010/execute \
+  -H 'Content-Type: application/json' \
+  -d '{"workflow": {"version":"1.0.0","components":[],"connections":[]}, "prompt": "Hello"}'
+```

--- a/packages/studio-server/src/index.ts
+++ b/packages/studio-server/src/index.ts
@@ -65,6 +65,20 @@ app.post('/workflows/:name', (req, res) => {
   res.json({ saved: true });
 });
 
+app.post('/execute', async (req, res) => {
+  const { workflow, prompt } = req.body || {};
+  if (!workflow) return res.status(400).json({ error: 'workflow required' });
+
+  const agent = Agent.import(workflow);
+  try {
+    const result = await agent.prompt(prompt || '');
+    res.json(result);
+  } catch (err: any) {
+    console.error('Failed to execute workflow', err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
 app.get('/run', async (req, res) => {
   const name = req.query.name as string;
   if (!name) return res.status(400).json({ error: 'name required' });

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -16,6 +16,8 @@ export default function App() {
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
   const [components, setComponents] = useState<any[]>([]);
+  const [prompt, setPrompt] = useState('');
+  const [result, setResult] = useState<string | null>(null);
 
   const fallbackComponents = [
     { name: 'TextInput' },
@@ -52,11 +54,33 @@ export default function App() {
 
   const onConnect = useCallback((params: any) => setEdges((eds) => addEdge(params, eds)), []);
 
+  const executeWorkflow = async () => {
+    const workflow = { nodes, edges };
+    const res = await fetch('http://localhost:3010/execute', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ workflow, prompt }),
+    });
+    const data = await res.json();
+    setResult(JSON.stringify(data));
+  };
+
   return (
     <ReactFlowProvider>
       <div style={{ display: 'flex', height: '100vh' }}>
         <div style={{ width: 150, borderRight: '1px solid #ccc', padding: 10 }}>
           <button onClick={addNode}>Add Node</button>
+          <div style={{ marginTop: 10 }}>
+            <input
+              type="text"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="Prompt"
+            />
+            <button onClick={executeWorkflow} style={{ display: 'block', marginTop: 5 }}>
+              Execute
+            </button>
+          </div>
           <ul>
             {components.map((c) => (
               <li key={c.name}>{c.name}</li>
@@ -75,6 +99,11 @@ export default function App() {
             <Background />
             <Controls />
           </ReactFlow>
+          {result && (
+            <pre style={{ position: 'absolute', bottom: 0, left: 0, right: 0, maxHeight: 200, overflow: 'auto', background: '#eee', margin: 0 }}>
+              {result}
+            </pre>
+          )}
         </div>
       </div>
     </ReactFlowProvider>


### PR DESCRIPTION
## Summary
- handle `/execute` in studio server to run arbitrary workflows
- document the new API endpoint
- wire up studio frontend to POST graph data and show results

## Testing
- `pnpm test:run` *(fails: Connection error, forbidden network requests)*

------
https://chatgpt.com/codex/tasks/task_e_68742264d580832ba6de0a00982aa585