### PR TITLE
Fix OpenRouter connector build

### DIFF
--- a/packages/core/src/subsystems/LLMManager/LLM.service/connectors/OpenAI.class.ts
+++ b/packages/core/src/subsystems/LLMManager/LLM.service/connectors/OpenAI.class.ts
@@ -78,7 +78,7 @@ export class OpenAIConnector extends LLMConnector {
     private validImageMimeTypes = SUPPORTED_MIME_TYPES_MAP.OpenAI.image;
     private validDocumentMimeTypes = SUPPORTED_MIME_TYPES_MAP.OpenAI.document;
 
-    private async getClient(params: ILLMRequestContext): Promise<OpenAI> {
+    protected async getClient(params: ILLMRequestContext): Promise<OpenAI> {
         const apiKey = (params.credentials as BasicCredentials)?.apiKey;
         const baseURL = params?.modelInfo?.baseURL;
 

--- a/packages/core/src/subsystems/LLMManager/LLM.service/connectors/OpenRouter.class.ts
+++ b/packages/core/src/subsystems/LLMManager/LLM.service/connectors/OpenRouter.class.ts
@@ -1,19 +1,14 @@
-import { OpenAIConnector, TOpenAIConnectorParams } from './OpenAI.class';
-import { TLLMProvider } from '@sre/types/LLM.types';
+import { OpenAIConnector } from './OpenAI.class';
+import { BasicCredentials, ILLMRequestContext } from '@sre/types/LLM.types';
 import { Logger } from '@sre/helpers/Log.helper';
 
 const console = Logger('OpenRouter');
 
 export class OpenRouterConnector extends OpenAIConnector {
-    public name: string = 'OpenRouter';
-    public provider: TLLMProvider = 'OpenRouter';
+    public name = 'LLM:OpenRouter';
 
-    constructor(params?: TOpenAIConnectorParams) {
-        super(params);
-        this.client = this.getClient(params?.apiKey);
-    }
-
-    protected async getClient(apiKey?: string) {
+    protected async getClient(params: ILLMRequestContext) {
+        let apiKey = (params.credentials as BasicCredentials)?.apiKey;
         if (!apiKey) apiKey = process.env.OPENROUTER_API_KEY;
 
         if (!apiKey) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,10 @@ importers:
         version: 5.8.3
 
   packages/cli:
+    dependencies:
+      '@smythos/sre':
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.14.0
@@ -81,9 +85,6 @@ importers:
       '@smythos/sdk':
         specifier: workspace:*
         version: link:../sdk
-      '@smythos/sre':
-        specifier: workspace:*
-        version: link:../core
       '@types/extract-zip':
         specifier: ^2.0.3
         version: 2.0.3


### PR DESCRIPTION
## Summary
- allow subclasses to override `OpenAIConnector.getClient`
- update `OpenRouterConnector` to use new `getClient` signature
- refresh pnpm lockfile

## Testing
- `pnpm build`
- `pnpm test` *(fails: Please provide an API key for OpenRouter etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68742cf08cbc832b9dd241d4b4d4aef3