### PR TITLE
Add workflow serialization utility to studio

### DIFF
--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -10,3 +10,21 @@ pnpm --filter @smythos/studio-server dev
 
 Once running the Studio will load components from `http://localhost:3010/components`.
 Make sure the server remains running whenever you use the Studio; otherwise component loading will fail.
+
+## Workflow Serialization
+
+The Studio converts visual workflows into the JSON format accepted by `Agent.import` before execution. The `serializeWorkflow` utility produces objects with the following structure:
+
+```json
+{
+  "version": "1.0.0",
+  "components": [
+    { "id": "1", "name": "TextInput", "data": { "placeholder": "hi" } }
+  ],
+  "connections": [
+    { "sourceId": "1", "sourceIndex": 0, "targetId": "2", "targetIndex": 0 }
+  ]
+}
+```
+
+This payload is sent to the studio server for execution and can be loaded directly with `Agent.import`.

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -7,6 +7,7 @@ import ReactFlow, {
   useNodesState,
   ReactFlowProvider,
 } from 'reactflow';
+import { serializeWorkflow } from './utils/serializeWorkflow';
 import TextInputNode from './nodes/TextInputNode';
 import HTTPCallNode from './nodes/HTTPCallNode';
 import 'reactflow/dist/style.css';
@@ -64,7 +65,7 @@ export default function App() {
   };
 
   const executeWorkflow = async () => {
-    const workflow = { nodes, edges };
+    const workflow = serializeWorkflow(nodes, edges);
     const res = await fetch('http://localhost:3010/execute', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/packages/studio/src/utils/serializeWorkflow.ts
+++ b/packages/studio/src/utils/serializeWorkflow.ts
@@ -1,0 +1,42 @@
+export interface ComponentData {
+  id: string;
+  name: string;
+  data: any;
+}
+
+export interface ConnectionData {
+  sourceId: string;
+  sourceIndex: number;
+  targetId: string;
+  targetIndex: number;
+}
+
+export interface WorkflowData {
+  version: string;
+  components: ComponentData[];
+  connections: ConnectionData[];
+}
+
+/**
+ * Convert ReactFlow nodes and edges into the Agent workflow format.
+ */
+export function serializeWorkflow(nodes: any[], edges: any[]): WorkflowData {
+  const components = nodes.map((n) => ({
+    id: n.id,
+    name: n.type,
+    data: n.data?.params || {},
+  }));
+
+  const connections = edges.map((e) => ({
+    sourceId: e.source,
+    sourceIndex: 0,
+    targetId: e.target,
+    targetIndex: 0,
+  }));
+
+  return {
+    version: '1.0.0',
+    components,
+    connections,
+  };
+}

--- a/packages/studio/tests/unit/serializeWorkflow.test.ts
+++ b/packages/studio/tests/unit/serializeWorkflow.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { serializeWorkflow } from '../../src/utils/serializeWorkflow';
+
+describe('serializeWorkflow', () => {
+  it('converts nodes to components', () => {
+    const nodes = [
+      { id: '1', type: 'TextInput', data: { params: { placeholder: 'hi' } } },
+    ];
+    const edges: any[] = [];
+    const wf = serializeWorkflow(nodes, edges);
+    expect(wf.components).toEqual([
+      { id: '1', name: 'TextInput', data: { placeholder: 'hi' } },
+    ]);
+    expect(wf.connections).toEqual([]);
+  });
+
+  it('converts edges to connections', () => {
+    const nodes = [
+      { id: '1', type: 'TextInput', data: { params: {} } },
+      { id: '2', type: 'HTTPCall', data: { params: {} } },
+    ];
+    const edges = [
+      { source: '1', target: '2' },
+    ];
+    const wf = serializeWorkflow(nodes, edges);
+    expect(wf.connections).toEqual([
+      { sourceId: '1', sourceIndex: 0, targetId: '2', targetIndex: 0 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add serializeWorkflow helper to map ReactFlow data to Agent format
- document the workflow serialization format in Studio README
- update App to use the serializer when executing workflows
- test serializeWorkflow utility

## Testing
- `pnpm test:run` *(fails: Cannot read properties of undefined, Please provide an API key, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6874c196f3b8832b81f68d1fe9c49458