### PR TITLE
Add output path support for terminal nodes

### DIFF
--- a/packages/studio-server/tests/server.test.ts
+++ b/packages/studio-server/tests/server.test.ts
@@ -22,12 +22,16 @@ describe('studio-server', () => {
   it('POST /execute runs workflow', async () => {
     const workflowPath = path.join(__dirname, '../workflows/echo.smyth');
     const workflow = JSON.parse(fs.readFileSync(workflowPath, 'utf8'));
+    const tmpOutput = path.join(__dirname, 'tmp-output.txt');
+    if (fs.existsSync(tmpOutput)) fs.unlinkSync(tmpOutput);
     const res = await request(app)
       .post('/execute')
-      .send({ workflow })
+      .send({ workflow, outputPaths: { end: tmpOutput } })
       .set('Content-Type', 'application/json');
     expect(res.status).toBe(200);
     expect(res.body).toBeTypeOf('object');
     expect(Object.keys(res.body).length).toBeGreaterThan(0);
+    expect(fs.existsSync(tmpOutput)).toBe(true);
+    fs.unlinkSync(tmpOutput);
   });
 });

--- a/packages/studio/tests/unit/App.test.tsx
+++ b/packages/studio/tests/unit/App.test.tsx
@@ -53,4 +53,24 @@ describe('App component', () => {
     const pre = await screen.findByTestId('node-data');
     expect(pre.textContent).toContain('hello');
   });
+
+  it('shows output path for terminal nodes', async () => {
+    const components = [
+      { name: 'TextInput', settings: {} },
+    ];
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => components,
+    }) as any;
+
+    render(<App />);
+
+    const btn = await screen.findByText('TextInput');
+    fireEvent.click(btn);
+
+    const [, nodeEl] = await screen.findAllByText('TextInput');
+    fireEvent.click(nodeEl);
+
+    expect(await screen.findByTestId('output-path')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- allow specifying an output path for nodes without outgoing edges
- send output path information when executing a workflow
- save execution output to given paths on the server
- cover new behaviour with unit and integration tests

## Testing
- `pnpm install --frozen-lockfile`
- `npx vitest run` *(fails: 10 failed, 11 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6874c4297610832b869074756eff45d8