### PR TITLE
Update Studio docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,19 @@ The **SDK** provides a clean, developer-friendly abstraction layer over the SRE 
 The **SRE CLI** helps you get started quickly with scaffolding and project management.
 
 
+### Studio - `packages/studio`
+
+The web-based workflow builder. Follow the instructions in
+[`packages/studio/README.md`](packages/studio/README.md) to start the app.
+
+
 ### Studio Server - `packages/studio-server`
 Run the development server with:
 ```bash
 pnpm --filter @smythos/studio-server dev
 ```
+See [`packages/studio-server/README.md`](packages/studio-server/README.md) for
+available endpoints and usage details.
 ## Code examples
 
 The SDK allows you to build agents with code or load and run a .smyth file.

--- a/packages/studio-server/README.md
+++ b/packages/studio-server/README.md
@@ -17,14 +17,29 @@ available components with:
 curl http://localhost:3010/components
 ```
 
+This endpoint returns an array of component descriptors. Each entry contains the
+component `name`, the configurable `settings` schema and any expected `inputs`.
+Example response:
+
+```json
+[
+  {
+    "name": "TextInput",
+    "settings": { "placeholder": { "type": "string" } },
+    "inputs": {}
+  }
+]
+```
+
 ## API
 
 ### `POST /execute`
 
 Execute a workflow sent in the request body. The payload must include a
 `workflow` object matching the SmythOS agent schema and an optional `prompt`
-string. The server imports the workflow using `Agent.import`, runs it with the
-provided prompt and returns the result as JSON.
+string. You can also specify `outputPaths` to save terminal node output to disk.
+The server imports the workflow using `Agent.import`, runs it with the provided
+prompt and returns the result as JSON.
 
 Example request:
 
@@ -32,4 +47,19 @@ Example request:
 curl -X POST http://localhost:3010/execute \
   -H 'Content-Type: application/json' \
   -d '{"workflow": {"version":"1.0.0","components":[],"connections":[]}, "prompt": "Hello"}'
+```
+
+The `workflow` object must include a `version` and arrays of `components` and
+`connections` as shown below:
+
+```json
+{
+  "version": "1.0.0",
+  "components": [
+    { "id": "1", "name": "TextInput", "data": { "placeholder": "hi" } }
+  ],
+  "connections": [
+    { "sourceId": "1", "sourceIndex": 0, "targetId": "2", "targetIndex": 0 }
+  ]
+}
 ```

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -1,15 +1,30 @@
 # SmythOS Studio
 
-The Studio UI fetches available components from a running instance of the Studio Server. By default the server listens on `http://localhost:3010`.
+The Studio UI fetches available components from a running instance of the Studio
+Server. By default the server listens on `http://localhost:3010`.
 
-To start the server in development run:
+1. Build the SRE and dependencies:
 
-```bash
-pnpm --filter @smythos/studio-server dev
-```
+   ```bash
+   pnpm build
+   ```
 
-Once running the Studio will load components from `http://localhost:3010/components`.
-Make sure the server remains running whenever you use the Studio; otherwise component loading will fail.
+2. Start the Studio Server:
+
+   ```bash
+   pnpm --filter @smythos/studio-server dev
+   ```
+
+3. In another terminal, run the Studio app:
+
+   ```bash
+   pnpm --filter @smythos/studio dev
+   ```
+
+Once both are running the Studio will load components from
+`http://localhost:3010/components`. Keep the server running whenever you use the
+Studio; otherwise component loading will fail. The UI is served by Vite on
+`http://localhost:5173` by default.
 
 ## Workflow Serialization
 


### PR DESCRIPTION
## Summary
- document endpoints and JSON format in `studio-server` README
- improve Studio README with start instructions
- link to Studio docs from the root README

## Testing
- `pnpm test:run` *(fails: Please provide an API key for OpenRouter)*

------
https://chatgpt.com/codex/tasks/task_e_6874ca34f84c832bb890d5a981cb2346