### PR TITLE
Fix debug log helper path

### DIFF
--- a/packages/core/tests/integration/log/debug-log.test.ts
+++ b/packages/core/tests/integration/log/debug-log.test.ts
@@ -4,7 +4,7 @@ import os from 'os';
 import path from 'path';
 import { ConnectorService } from '@sre/Core/ConnectorsService';
 import { AccessCandidate } from '@sre/Security/AccessControl/AccessCandidate.class';
-import { setupSRE } from '../utils/sre';
+import { setupSRE } from '../../utils/sre';
 import { Logger } from '@sre/helpers/Log.helper';
 
 const agentId = 'test-agent';


### PR DESCRIPTION
## Summary
- fix import path for `setupSRE` in debug log tests

## Testing
- `pnpm test` *(fails: Cannot redefine property: crypto)*

------
https://chatgpt.com/codex/tasks/task_e_6874d97d4424832b9ec4b0c6b1028b9f