### PR TITLE
Map workspace packages directly in Vitest

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,14 @@
+import path from 'path';
 import { defineConfig } from 'vitest/config';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
+    resolve: {
+        alias: {
+            '@smythos/sre': path.resolve(__dirname, 'packages/core/src'),
+            '@smythos/sdk': path.resolve(__dirname, 'packages/sdk/src'),
+        },
+    },
     plugins: [tsconfigPaths()],
     test: {
         globals: true,


### PR DESCRIPTION
## Summary
- add path-based alias for `@smythos/sre` and `@smythos/sdk`

## Testing
- `pnpm test` *(fails: strong-data-typing.test.ts, conversation.test.ts and others)*

------
https://chatgpt.com/codex/tasks/task_e_6874dc2c19bc832b8949e76593891b2a