### PR TITLE
Fix neon account test insert

### DIFF
--- a/packages/core/tests/integration/account/neon-account.test.ts
+++ b/packages/core/tests/integration/account/neon-account.test.ts
@@ -21,7 +21,10 @@ beforeAll(async () => {
     await db.public.none(`INSERT INTO AgentSettings VALUES ('agent1', 'setting1', 'avalue1');`);
 
     const aclText = new ACL().addAccess(TAccessRole.User, 'user1', TAccessLevel.Read).serializedACL;
-    await db.public.none(`INSERT INTO ResourceACL VALUES ('res1', $1);`, [aclText]);
+    await db.public.none(
+        'INSERT INTO ResourceACL (resource_id, acl) VALUES ($1, $2)',
+        ['res1', aclText],
+    );
 
     account = new NeonAccount({ host: 'localhost' });
     (account as any).pool = new adapter.Pool();


### PR DESCRIPTION
## Summary
- adjust the SQL insert statement in the neon account integration test to pass both fields as parameters

## Testing
- `npx vitest run packages/core/tests/integration/account/neon-account.test.ts` *(fails: Parameter $1 not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874de2bdf24832ba451c3cd77bccf7e