### PR TITLE
Use local sample file in BinaryInput test

### DIFF
--- a/packages/core/tests/unit/core/BinaryInput.test.ts
+++ b/packages/core/tests/unit/core/BinaryInput.test.ts
@@ -32,16 +32,15 @@ describe('BinaryInput Tests', () => {
     });
 
     it('should handle URL input', async () => {
-        const imageUrl = 'https://fastly.picsum.photos/id/358/536/354.jpg?hmac=B5MKNtRmR2RBqLeb7thQXV573rQcrX5Hrih-N8SuliM';
-
-        const binary = new BinaryInput(imageUrl);
+        const imagePath = testData.getDataPath('file-samples/sample.png');
+        const binary = new BinaryInput(`file://${imagePath}`);
         await binary.ready();
 
         const jsonData = await binary.getJsonData(mockCandidate);
-        expect(jsonData.mimetype).toBe('image/jpeg');
-        expect(jsonData.size).toBe(35108);
-        expect(jsonData.name).toContain('.jpg');
-        expect(jsonData.url).toMatch(/^smythfs:\/\/.*\.jpg$/);
+        expect(jsonData.mimetype).toBe('image/png');
+        expect(jsonData.size).toBe(fs.statSync(imagePath).size);
+        expect(jsonData.name).toContain('.png');
+        expect(jsonData.url).toMatch(/^smythfs:\/\/.*\.png$/);
     });
 
     it('should handle base64 encoded data', async () => {


### PR DESCRIPTION
## Summary
- point BinaryInput URL test to a local sample image

## Testing
- `pnpm test:run` *(fails: Cannot read properties of undefined and network access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6874e0443d50832b8270589f82f3c953