### PR TITLE
Handle missing API keys in LLM tests

### DIFF
--- a/packages/core/tests/integration/llm/conversation.test.ts
+++ b/packages/core/tests/integration/llm/conversation.test.ts
@@ -1,4 +1,11 @@
 import { describe, expect, it } from 'vitest';
+
+const run =
+    process.env.OPENROUTER_API_KEY &&
+    process.env.ANTHROPIC_API_KEY &&
+    (process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY)
+        ? it
+        : it.skip;
 import { Conversation } from '@sre/helpers/Conversation.helper';
 import { setupSRE } from '../../utils/sre';
 import { models as LLM_MODELS } from '@sre/LLMManager/models';
@@ -27,7 +34,7 @@ const LLM_OUTPUT_VALIDATOR = 'Yohohohooooo!';
 const WORD_INCLUSION_PROMPT = `\nThe response must includes "${LLM_OUTPUT_VALIDATOR}".`;
 
 describe.each(Object.keys(models))('Conversation Tests: %s', (id: string) => {
-    it(
+    run(
         'runs a conversation with tool use',
         async () => {
             const specUrl = 'https://clzddo5xy19zg3mjrmr3urtfd.agent.stage.smyth.ai/api-docs/openapi-llm.json';
@@ -47,7 +54,7 @@ describe.each(Object.keys(models))('Conversation Tests: %s', (id: string) => {
         TIMEOUT
     );
 
-    it(
+    run(
         'runs a conversation with tool use in stream mode',
         async () => {
             const specUrl = 'https://clzddo5xy19zg3mjrmr3urtfd.agent.stage.smyth.ai/api-docs/openapi-llm.json';
@@ -78,7 +85,7 @@ describe.each(Object.keys(models))('Conversation Tests: %s', (id: string) => {
         TIMEOUT * 10
     );
 
-    it(
+    run(
         'handles multiple tool calls in a single conversation',
         async () => {
             const specUrl = 'https://clzddo5xy19zg3mjrmr3urtfd.agent.stage.smyth.ai/api-docs/openapi-llm.json';
@@ -109,7 +116,7 @@ describe.each(Object.keys(models))('Conversation Tests: %s', (id: string) => {
         TIMEOUT * 2
     );
 
-    it(
+    run(
         'handles follow-up questions correctly',
         async () => {
             const specUrl = 'https://clzddo5xy19zg3mjrmr3urtfd.agent.stage.smyth.ai/api-docs/openapi-llm.json';
@@ -129,7 +136,7 @@ describe.each(Object.keys(models))('Conversation Tests: %s', (id: string) => {
     );
 
     describe('Passthrough Mode', () => {
-        it(
+        run(
             'should passthrough responses immediately midst agent execution',
             async () => {
                 const conv = new Conversation(id, 'passthrough-llm-test');

--- a/packages/sdk/tests/agent.test.ts
+++ b/packages/sdk/tests/agent.test.ts
@@ -2,6 +2,8 @@
 import { SRE } from '@smythos/sre';
 import { LLM, LLMInstance, Model, Agent, Component } from '../src/index';
 import { expect, describe, it } from 'vitest';
+
+const run = process.env.OPENROUTER_API_KEY ? it : it.skip;
 // SRE.init({
 //     Vault: {
 //         Connector: 'JSONFileVault',
@@ -12,7 +14,7 @@ import { expect, describe, it } from 'vitest';
 // });
 
 describe('SDK Agent Tests', () => {
-    it('imported agent', async () => {
+    run('imported agent', async () => {
         const agent = Agent.import('./packages/sdk/tests/data/AgentData/crypto-info-agent.smyth', {
             model: Model.OpenRouter('gpt-4o-mini', { maxTokens: 10 }),
         });
@@ -23,7 +25,7 @@ describe('SDK Agent Tests', () => {
         console.log(result);
     });
 
-    it('Declarative Agent', async () => {
+    run('Declarative Agent', async () => {
         const agent = new Agent({
             name: 'SRE Assistant',
             behavior:
@@ -65,7 +67,7 @@ describe('SDK Agent Tests', () => {
         console.log(result2);
     });
 
-    it('Procedural Agent', async () => {
+    run('Procedural Agent', async () => {
         const agent = new Agent({ name: 'Evaluator', model: 'gpt-4o' });
 
         agent.addSkill({

--- a/packages/sdk/tests/llm.test.ts
+++ b/packages/sdk/tests/llm.test.ts
@@ -3,6 +3,8 @@ import { SRE } from '@smythos/sre';
 import { LLM, LLMInstance, Agent, Component } from '../src/index';
 import { expect, describe, it } from 'vitest';
 
+const run = process.env.OPENROUTER_API_KEY ? it : it.skip;
+
 import { TLLMProvider } from '../src/types/ExportedSRETypes';
 
 declare module '../src/types/SDKTypes' {
@@ -21,7 +23,7 @@ declare module '../src/types/SDKTypes' {
 // });
 
 describe('SDK LLM Tests', () => {
-    it('LLM - Prompt from LLMInstance', async () => {
+    run('LLM - Prompt from LLMInstance', async () => {
         //initialize the LLM
         const llm = new LLMInstance(TLLMProvider.OpenRouter, { model: 'gpt-4o' });
 
@@ -32,7 +34,7 @@ describe('SDK LLM Tests', () => {
         expect(result).toContain('Paris');
     });
 
-    it('LLM - Prompt from named LLM', async () => {
+    run('LLM - Prompt from named LLM', async () => {
         const llm = LLM.OpenRouter('gpt-4o-mini', {
             temperature: 0.1,
             maxTokens: 100,
@@ -44,7 +46,7 @@ describe('SDK LLM Tests', () => {
         expect(result).toContain('Paris');
     });
 
-    it('LLM - Prompt with attachments', async () => {
+    run('LLM - Prompt with attachments', async () => {
         const llm = LLM.OpenRouter('gpt-4o-mini', {
             temperature: 0.1,
             maxTokens: 100,
@@ -56,9 +58,9 @@ describe('SDK LLM Tests', () => {
 
         expect(result).toBeDefined();
         expect(result).toContain('Paris');
-    });    
+    });
 
-    it('LLMProxy - Chat', async () => {
+    run('LLMProxy - Chat', async () => {
         const llm = LLM.OpenRouter({ model: 'gpt-4o' });
 
         const chat = llm.chat();
@@ -72,7 +74,7 @@ describe('SDK LLM Tests', () => {
         expect(result3).toContain('John Doe');
     });
 
-    it('LLM - StreamPrompt', async () => {
+    run('LLM - StreamPrompt', async () => {
         const llm = LLM.OpenRouter({ model: 'gpt-4o' });
 
         const eventEmitter = await llm.prompt('What is the capital of France?').stream();

--- a/packages/sdk/tests/vectordb.test.ts
+++ b/packages/sdk/tests/vectordb.test.ts
@@ -1,8 +1,10 @@
 import { describe, it } from 'vitest';
+
+const run = process.env.PINECONE_API_KEY && process.env.OPENROUTER_API_KEY ? it : it.skip;
 import { Model, VectorDB } from '../src/index';
 
 describe('SDK VectorDB Tests', () => {
-    it('Standalone insert doc', async () => {
+    run('Standalone insert doc', async () => {
         //const ramVectorDB = new VectorDBInstance(TVectorDBProvider.RAMVec, { namespace: 'test' });
         //const ramVectorDB = VectorDB.RAMVec('test');
         const pinecone = VectorDB.Pinecone('test', {


### PR DESCRIPTION
## Summary
- skip LLM-based tests when credentials are not available

## Testing
- `pnpm test` *(fails: Protocol mismatch, missing API key, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6874e7171870832b8d106f6299b346a6