### PR TITLE
Add workflow save/load to Studio

### DIFF
--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -34,6 +34,8 @@ Studio; otherwise component loading will fail. The UI is served by Vite on
 - **Prompt field** lets you enter a prompt that will be passed to the workflow
   when executed.
 - **Execute** runs the current workflow with the prompt you entered.
+- **Save** stores the current workflow on the Studio Server.
+- **Load** retrieves a previously saved workflow from the server.
 
 Selecting a node opens a panel on the right where you can edit its parameters.
 If the node does not feed into any others, an **Output Path** field appears to

--- a/packages/studio/src/utils/deserializeWorkflow.ts
+++ b/packages/studio/src/utils/deserializeWorkflow.ts
@@ -1,0 +1,21 @@
+export interface SerializedWorkflow {
+  components: Array<{ id: string; name: string; data?: any }>;
+  connections: Array<{ sourceId: string; sourceIndex: number; targetId: string; targetIndex: number }>;
+}
+
+export function deserializeWorkflow(workflow: SerializedWorkflow) {
+  const nodes = (workflow.components || []).map((c, idx) => ({
+    id: c.id,
+    type: c.name,
+    position: { x: idx * 50, y: idx * 80 },
+    data: { label: c.name, params: c.data || {} },
+  }));
+
+  const edges = (workflow.connections || []).map((c, idx) => ({
+    id: `e${idx}`,
+    source: c.sourceId,
+    target: c.targetId,
+  }));
+
+  return { nodes, edges };
+}


### PR DESCRIPTION
## Summary
- add workflow saving and loading logic in Studio app
- support workflow deserialization
- document Save/Load buttons in Studio README

## Testing
- `pnpm test:run` *(fails: ERR_ASSERTION etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68751661719c832b82be8d080cd92e46