### PR TITLE
Validate connection types in Studio

### DIFF
--- a/packages/studio-server/src/index.ts
+++ b/packages/studio-server/src/index.ts
@@ -5,136 +5,133 @@ import path from 'path';
 import os from 'os';
 import { Agent } from '@smythos/sdk';
 import { startMcpServer } from '../../cli/src/commands/agent/mcp.cmd';
-import {
-  LocalComponentConnector,
-  ConnectorService,
-  AccessCandidate,
-  SRE,
-} from '@smythos/sre';
+import { LocalComponentConnector, ConnectorService, AccessCandidate, SRE } from '@smythos/sre';
 
 const WORKFLOWS_DIR = path.join(__dirname, '../workflows');
 
 async function bootSRE() {
-  if (process.env.NODE_ENV === 'test') {
-    SRE.init();
-    await SRE.ready();
-    return;
-  }
-  // Initialize SRE using startMcpServer with a minimal agent
-  const dummyAgent = {
-    version: '1.0',
-    data: { id: 'init', components: [], connections: [] },
-  };
-  await startMcpServer(dummyAgent, 'stdio', 0, {});
+    if (process.env.NODE_ENV === 'test') {
+        SRE.init();
+        await SRE.ready();
+        return;
+    }
+    // Initialize SRE using startMcpServer with a minimal agent
+    const dummyAgent = {
+        version: '1.0',
+        data: { id: 'init', components: [], connections: [] },
+    };
+    await startMcpServer(dummyAgent, 'stdio', 0, {});
 }
 
 export async function createApp() {
-  await bootSRE();
+    await bootSRE();
 
-  const app = express();
-  app.use(cors());
-  app.use(express.json());
+    const app = express();
+    app.use(cors());
+    app.use(express.json());
 
-app.get('/components', async (_req, res) => {
-  try {
-    const connector = ConnectorService.getComponentConnector() as LocalComponentConnector;
-    const requester = connector.requester(AccessCandidate.agent('studio-server'));
-    const components = await requester.getAll();
-    const componentDetails = Object.entries(components).map(([name, instance]: [string, any]) => ({
-      name,
-      settings: instance.schema?.settings || {},
-      inputs: instance.schema?.inputs || {},
-    }));
-    res.json(componentDetails);
-  } catch (err: any) {
-    console.error('Failed to load components', err);
-    res.status(500).json({ error: 'failed to load components' });
-  }
-});
-
-app.get('/workflows', (_req, res) => {
-  const files = fs.readdirSync(WORKFLOWS_DIR).filter((f) => f.endsWith('.smyth'));
-  res.json(files.map((f) => path.basename(f, '.smyth')));
-});
-
-app.get('/workflows/:name', (req, res) => {
-  const file = path.join(WORKFLOWS_DIR, `${req.params.name}.smyth`);
-  if (!fs.existsSync(file)) return res.status(404).json({ error: 'Not found' });
-  const agent = Agent.import(JSON.parse(fs.readFileSync(file, 'utf8')));
-  res.json(agent.data);
-});
-
-app.post('/workflows/:name', (req, res) => {
-  const file = path.join(WORKFLOWS_DIR, `${req.params.name}.smyth`);
-  const agent = Agent.import(req.body);
-  fs.writeFileSync(file, JSON.stringify(agent.export(), null, 2));
-  res.json({ saved: true });
-});
-
-app.post('/execute', async (req, res) => {
-  const { workflow, prompt, outputPaths } = req.body || {};
-  if (!workflow) return res.status(400).json({ error: 'workflow required' });
-
-  const agent = Agent.import(workflow);
-  try {
-    const result = await agent.prompt(prompt || '');
-    if (outputPaths && typeof outputPaths === 'object') {
-      for (const id of Object.keys(outputPaths)) {
-        const p = outputPaths[id];
+    app.get('/components', async (_req, res) => {
         try {
-          fs.mkdirSync(path.dirname(p), { recursive: true });
-          fs.writeFileSync(p, typeof result === 'string' ? result : JSON.stringify(result, null, 2));
-        } catch (e) {
-          console.error('Failed to write output', e);
+            const connector = ConnectorService.getComponentConnector() as LocalComponentConnector;
+            const requester = connector.requester(AccessCandidate.agent('studio-server'));
+            const components = await requester.getAll();
+            const componentDetails = Object.entries(components).map(([name, instance]: [string, any]) => ({
+                name,
+                settings: instance.schema?.settings || {},
+                inputs: instance.schema?.inputs || {},
+                outputs: instance.schema?.outputs || {},
+            }));
+            res.json(componentDetails);
+        } catch (err: any) {
+            console.error('Failed to load components', err);
+            res.status(500).json({ error: 'failed to load components' });
         }
-      }
-    }
-    res.json(result);
-  } catch (err: any) {
-    console.error('Failed to execute workflow', err);
-    res.status(500).json({ error: err.message });
-  }
-});
+    });
 
-app.get('/run', async (req, res) => {
-  const name = req.query.name as string;
-  if (!name) return res.status(400).json({ error: 'name required' });
-  const file = path.join(WORKFLOWS_DIR, `${name}.smyth`);
-  if (!fs.existsSync(file)) return res.status(404).json({ error: 'Workflow not found' });
-  const agent = Agent.import(JSON.parse(fs.readFileSync(file, 'utf8')));
+    app.get('/workflows', (_req, res) => {
+        const files = fs.readdirSync(WORKFLOWS_DIR).filter((f) => f.endsWith('.smyth'));
+        res.json(files.map((f) => path.basename(f, '.smyth')));
+    });
 
-  res.setHeader('Cache-Control', 'no-cache');
-  res.setHeader('Content-Type', 'text/event-stream');
-  res.setHeader('Connection', 'keep-alive');
-  res.flushHeaders();
+    app.get('/workflows/:name', (req, res) => {
+        const file = path.join(WORKFLOWS_DIR, `${req.params.name}.smyth`);
+        if (!fs.existsSync(file)) return res.status(404).json({ error: 'Not found' });
+        const agent = Agent.import(JSON.parse(fs.readFileSync(file, 'utf8')));
+        res.json(agent.data);
+    });
 
-  agent.addSSE(res);
-  const result = await agent.prompt(req.query.prompt as string || '').catch((e) => ({ error: e.message }));
-  res.write(`event: result\ndata: ${JSON.stringify(result)}\n\n`);
-  res.end();
-});
+    app.post('/workflows/:name', (req, res) => {
+        const file = path.join(WORKFLOWS_DIR, `${req.params.name}.smyth`);
+        const agent = Agent.import(req.body);
+        fs.writeFileSync(file, JSON.stringify(agent.export(), null, 2));
+        res.json({ saved: true });
+    });
 
-app.get('/logs/:agentId', (req, res) => {
-  const file = path.join(os.homedir(), '.smyth', 'logs', req.params.agentId, 'debug.jsonl');
-  if (!fs.existsSync(file)) return res.json([]);
-  const entries = fs.readFileSync(file, 'utf8')
-    .split('\n')
-    .filter(Boolean)
-    .map((l) => JSON.parse(l));
-  res.json(entries);
-});
+    app.post('/execute', async (req, res) => {
+        const { workflow, prompt, outputPaths } = req.body || {};
+        if (!workflow) return res.status(400).json({ error: 'workflow required' });
 
-  return app;
+        const agent = Agent.import(workflow);
+        try {
+            const result = await agent.prompt(prompt || '');
+            if (outputPaths && typeof outputPaths === 'object') {
+                for (const id of Object.keys(outputPaths)) {
+                    const p = outputPaths[id];
+                    try {
+                        fs.mkdirSync(path.dirname(p), { recursive: true });
+                        fs.writeFileSync(p, typeof result === 'string' ? result : JSON.stringify(result, null, 2));
+                    } catch (e) {
+                        console.error('Failed to write output', e);
+                    }
+                }
+            }
+            res.json(result);
+        } catch (err: any) {
+            console.error('Failed to execute workflow', err);
+            res.status(500).json({ error: err.message });
+        }
+    });
+
+    app.get('/run', async (req, res) => {
+        const name = req.query.name as string;
+        if (!name) return res.status(400).json({ error: 'name required' });
+        const file = path.join(WORKFLOWS_DIR, `${name}.smyth`);
+        if (!fs.existsSync(file)) return res.status(404).json({ error: 'Workflow not found' });
+        const agent = Agent.import(JSON.parse(fs.readFileSync(file, 'utf8')));
+
+        res.setHeader('Cache-Control', 'no-cache');
+        res.setHeader('Content-Type', 'text/event-stream');
+        res.setHeader('Connection', 'keep-alive');
+        res.flushHeaders();
+
+        agent.addSSE(res);
+        const result = await agent.prompt((req.query.prompt as string) || '').catch((e) => ({ error: e.message }));
+        res.write(`event: result\ndata: ${JSON.stringify(result)}\n\n`);
+        res.end();
+    });
+
+    app.get('/logs/:agentId', (req, res) => {
+        const file = path.join(os.homedir(), '.smyth', 'logs', req.params.agentId, 'debug.jsonl');
+        if (!fs.existsSync(file)) return res.json([]);
+        const entries = fs
+            .readFileSync(file, 'utf8')
+            .split('\n')
+            .filter(Boolean)
+            .map((l) => JSON.parse(l));
+        res.json(entries);
+    });
+
+    return app;
 }
 
 export async function startServer() {
-  const app = await createApp();
-  const PORT = Number(process.env.PORT) || 3010;
-  return app.listen(PORT, () => {
-    console.log(`Studio server listening on http://localhost:${PORT}`);
-  });
+    const app = await createApp();
+    const PORT = Number(process.env.PORT) || 3010;
+    return app.listen(PORT, () => {
+        console.log(`Studio server listening on http://localhost:${PORT}`);
+    });
 }
 
 if (process.env.NODE_ENV !== 'test') {
-  startServer().catch(err => console.error(err));
+    startServer().catch((err) => console.error(err));
 }

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -1,12 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import ReactFlow, {
-  Background,
-  Controls,
-  addEdge,
-  useEdgesState,
-  useNodesState,
-  ReactFlowProvider,
-} from 'reactflow';
+import ReactFlow, { Background, Controls, addEdge, useEdgesState, useNodesState, ReactFlowProvider } from 'reactflow';
+import { canConnect } from './utils/connectUtils';
 import TextInputNode from './nodes/TextInputNode';
 import HTTPCallNode from './nodes/HTTPCallNode';
 import LLMPromptNode from './nodes/LLMPromptNode';
@@ -18,242 +12,256 @@ import 'reactflow/dist/style.css';
 const initialNodes = [];
 const initialEdges: any[] = [];
 const nodeTypes = {
-  TextInput: TextInputNode,
-  HTTPCall: HTTPCallNode,
-  LLMPrompt: LLMPromptNode,
-  CodeExec: CodeExecNode,
+    TextInput: TextInputNode,
+    HTTPCall: HTTPCallNode,
+    LLMPrompt: LLMPromptNode,
+    CodeExec: CodeExecNode,
 };
 
 export default function App() {
-  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
-  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
-  const [components, setComponents] = useState<any[]>([]);
-  const [workflows, setWorkflows] = useState<string[]>([]);
-  const [selectedWorkflow, setSelectedWorkflow] = useState('');
-  const [prompt, setPrompt] = useState('');
-  const [result, setResult] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+    const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+    const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+    const [components, setComponents] = useState<any[]>([]);
+    const [workflows, setWorkflows] = useState<string[]>([]);
+    const [selectedWorkflow, setSelectedWorkflow] = useState('');
+    const [prompt, setPrompt] = useState('');
+    const [result, setResult] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 
-  useEffect(() => {
-    async function loadComponents() {
-      try {
-        const res = await fetch('http://localhost:3010/components');
-        if (!res.ok) throw new Error(`Status ${res.status}`);
-        const data = await res.json();
-        setComponents(data);
-      } catch (err) {
-        console.error('Failed to fetch components', err);
-        setError('Failed to load components');
-      }
-    }
-
-    async function loadWorkflowsList() {
-      try {
-        const res = await fetch('http://localhost:3010/workflows');
-        if (res.ok) {
-          const names = await res.json();
-          setWorkflows(names);
+    useEffect(() => {
+        async function loadComponents() {
+            try {
+                const res = await fetch('http://localhost:3010/components');
+                if (!res.ok) throw new Error(`Status ${res.status}`);
+                const data = await res.json();
+                setComponents(data);
+            } catch (err) {
+                console.error('Failed to fetch components', err);
+                setError('Failed to load components');
+            }
         }
-      } catch (err) {
-        console.error('Failed to fetch workflows', err);
-      }
-    }
 
-    loadComponents();
-    loadWorkflowsList();
-  }, []);
+        async function loadWorkflowsList() {
+            try {
+                const res = await fetch('http://localhost:3010/workflows');
+                if (res.ok) {
+                    const names = await res.json();
+                    setWorkflows(names);
+                }
+            } catch (err) {
+                console.error('Failed to fetch workflows', err);
+            }
+        }
 
-  const addNode = (type: string) => {
-    setNodes((nds) => [
-      ...nds,
-      {
-        id: `${nds.length}`,
-        position: { x: Math.random() * 250, y: Math.random() * 250 },
-        data: { label: type, params: {} },
-        type,
-      },
-    ]);
-  };
+        loadComponents();
+        loadWorkflowsList();
+    }, []);
 
-  const onConnect = useCallback((params: any) => setEdges((eds) => addEdge(params, eds)), []);
+    const addNode = (type: string) => {
+        setNodes((nds) => [
+            ...nds,
+            {
+                id: `${nds.length}`,
+                position: { x: Math.random() * 250, y: Math.random() * 250 },
+                data: { label: type, params: {} },
+                type,
+            },
+        ]);
+    };
 
-  const updateNodeParams = (id: string, params: any) => {
-    setNodes((nds) =>
-      nds.map((n) => (n.id === id ? { ...n, data: { ...n.data, params } } : n))
+    const onConnect = useCallback(
+        (params: any) => {
+            if (canConnect(params, nodes, components)) {
+                setEdges((eds) => addEdge(params, eds));
+                setError(null);
+            } else {
+                setError('Incompatible connection');
+            }
+        },
+        [nodes, components],
     );
-  };
 
-  const updateNodeOutputPath = (id: string, outputPath: string) => {
-    setNodes((nds) =>
-      nds.map((n) => (n.id === id ? { ...n, data: { ...n.data, outputPath } } : n))
+    const updateNodeParams = (id: string, params: any) => {
+        setNodes((nds) => nds.map((n) => (n.id === id ? { ...n, data: { ...n.data, params } } : n)));
+    };
+
+    const updateNodeOutputPath = (id: string, outputPath: string) => {
+        setNodes((nds) => nds.map((n) => (n.id === id ? { ...n, data: { ...n.data, outputPath } } : n)));
+    };
+
+    const saveWorkflow = async () => {
+        const name = window.prompt('Workflow name');
+        if (!name) return;
+        const workflow = serializeWorkflow(nodes, edges);
+        await fetch(`http://localhost:3010/workflows/${encodeURIComponent(name)}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(workflow),
+        });
+        // refresh list
+        try {
+            const res = await fetch('http://localhost:3010/workflows');
+            if (res.ok) setWorkflows(await res.json());
+        } catch {}
+    };
+
+    const loadWorkflow = async (name: string) => {
+        try {
+            const res = await fetch(`http://localhost:3010/workflows/${encodeURIComponent(name)}`);
+            if (!res.ok) throw new Error();
+            const data = await res.json();
+            const { nodes: wfNodes, edges: wfEdges } = deserializeWorkflow(data);
+            setNodes(wfNodes);
+            setEdges(wfEdges);
+        } catch (err) {
+            console.error('Failed to load workflow', err);
+        }
+    };
+
+    const executeWorkflow = async () => {
+        const workflow = serializeWorkflow(nodes, edges);
+        const outputPaths = nodes.reduce(
+            (acc: any, n) => {
+                if (n.data?.outputPath) acc[n.id] = n.data.outputPath;
+                return acc;
+            },
+            {} as Record<string, string>,
+        );
+        const res = await fetch('http://localhost:3010/execute', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ workflow, prompt, outputPaths }),
+        });
+        const data = await res.json();
+        setResult(JSON.stringify(data));
+    };
+
+    return (
+        <ReactFlowProvider>
+            <div style={{ display: 'flex', height: '100vh' }}>
+                <div style={{ width: 150, borderRight: '1px solid #ccc', padding: 10 }}>
+                    {components.map((c) => (
+                        <button key={c.name} onClick={() => addNode(c.name)} style={{ display: 'block', marginBottom: 5 }}>
+                            {c.name}
+                        </button>
+                    ))}
+                    <div style={{ marginTop: 10 }}>
+                        <input type="text" value={prompt} onChange={(e) => setPrompt(e.target.value)} placeholder="Prompt" />
+                        <button onClick={executeWorkflow} style={{ display: 'block', marginTop: 5 }}>
+                            Execute
+                        </button>
+                        <button onClick={saveWorkflow} style={{ display: 'block', marginTop: 5 }}>
+                            Save
+                        </button>
+                        <div style={{ marginTop: 5 }}>
+                            <select
+                                value={selectedWorkflow}
+                                onChange={(e) => setSelectedWorkflow(e.target.value)}
+                                style={{ width: '100%', marginBottom: 5 }}
+                            >
+                                <option value="">Select workflow</option>
+                                {workflows.map((w) => (
+                                    <option key={w} value={w}>
+                                        {w}
+                                    </option>
+                                ))}
+                            </select>
+                            <button onClick={() => selectedWorkflow && loadWorkflow(selectedWorkflow)} style={{ display: 'block', marginTop: 0 }}>
+                                Load
+                            </button>
+                        </div>
+                    </div>
+                    {error && <div style={{ color: 'red', marginTop: 10 }}>{error}</div>}
+                </div>
+                <div style={{ flexGrow: 1, position: 'relative', display: 'flex' }}>
+                    <div style={{ flexGrow: 1 }}>
+                        <ReactFlow
+                            nodes={nodes}
+                            edges={edges}
+                            onNodesChange={onNodesChange}
+                            onEdgesChange={onEdgesChange}
+                            onConnect={onConnect}
+                            onNodeClick={(_, n) => setSelectedNodeId(n.id)}
+                            nodeTypes={nodeTypes}
+                            fitView
+                        >
+                            <Background />
+                            <Controls />
+                        </ReactFlow>
+                        {result && (
+                            <pre
+                                style={{
+                                    position: 'absolute',
+                                    bottom: 0,
+                                    left: 0,
+                                    right: 0,
+                                    maxHeight: 200,
+                                    overflow: 'auto',
+                                    background: '#eee',
+                                    margin: 0,
+                                }}
+                            >
+                                {result}
+                            </pre>
+                        )}
+                    </div>
+                    {selectedNodeId && (
+                        <div style={{ width: 200, borderLeft: '1px solid #ccc', padding: 10 }}>
+                            {components
+                                .filter((c) => c.name === nodes.find((n) => n.id === selectedNodeId)?.type)
+                                .map((c) => (
+                                    <div key={c.name}>
+                                        {Object.entries(c.settings || {}).map(([key, field]: any) => {
+                                            const value = nodes.find((n) => n.id === selectedNodeId)?.data.params?.[key] ?? '';
+                                            const inputProps = {
+                                                'data-testid': `param-${key}`,
+                                                value,
+                                                onChange: (e: any) => {
+                                                    const v =
+                                                        field.type === 'number'
+                                                            ? Number(e.target.value)
+                                                            : field.type === 'boolean'
+                                                              ? e.target.checked
+                                                              : e.target.value;
+                                                    updateNodeParams(selectedNodeId, {
+                                                        ...(nodes.find((n) => n.id === selectedNodeId)?.data.params || {}),
+                                                        [key]: v,
+                                                    });
+                                                },
+                                            } as any;
+                                            if (field.type === 'boolean') {
+                                                return (
+                                                    <label key={key} style={{ display: 'block', marginBottom: 5 }}>
+                                                        {key}
+                                                        <input type="checkbox" checked={!!value} {...inputProps} />
+                                                    </label>
+                                                );
+                                            }
+                                            return (
+                                                <label key={key} style={{ display: 'block', marginBottom: 5 }}>
+                                                    {key}
+                                                    <input type="text" {...inputProps} />
+                                                </label>
+                                            );
+                                        })}
+                                    </div>
+                                ))}
+                            {!edges.some((e) => e.source === selectedNodeId) && (
+                                <label style={{ display: 'block', marginTop: 5 }}>
+                                    Output Path
+                                    <input
+                                        type="text"
+                                        data-testid="output-path"
+                                        value={nodes.find((n) => n.id === selectedNodeId)?.data.outputPath || ''}
+                                        onChange={(e) => updateNodeOutputPath(selectedNodeId, e.target.value)}
+                                    />
+                                </label>
+                            )}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </ReactFlowProvider>
     );
-  };
-
-  const saveWorkflow = async () => {
-    const name = window.prompt('Workflow name');
-    if (!name) return;
-    const workflow = serializeWorkflow(nodes, edges);
-    await fetch(`http://localhost:3010/workflows/${encodeURIComponent(name)}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(workflow),
-    });
-    // refresh list
-    try {
-      const res = await fetch('http://localhost:3010/workflows');
-      if (res.ok) setWorkflows(await res.json());
-    } catch {}
-  };
-
-  const loadWorkflow = async (name: string) => {
-    try {
-      const res = await fetch(`http://localhost:3010/workflows/${encodeURIComponent(name)}`);
-      if (!res.ok) throw new Error();
-      const data = await res.json();
-      const { nodes: wfNodes, edges: wfEdges } = deserializeWorkflow(data);
-      setNodes(wfNodes);
-      setEdges(wfEdges);
-    } catch (err) {
-      console.error('Failed to load workflow', err);
-    }
-  };
-
-  const executeWorkflow = async () => {
-    const workflow = serializeWorkflow(nodes, edges);
-    const outputPaths = nodes.reduce((acc: any, n) => {
-      if (n.data?.outputPath) acc[n.id] = n.data.outputPath;
-      return acc;
-    }, {} as Record<string, string>);
-    const res = await fetch('http://localhost:3010/execute', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ workflow, prompt, outputPaths }),
-    });
-    const data = await res.json();
-    setResult(JSON.stringify(data));
-  };
-
-  return (
-    <ReactFlowProvider>
-      <div style={{ display: 'flex', height: '100vh' }}>
-        <div style={{ width: 150, borderRight: '1px solid #ccc', padding: 10 }}>
-          {components.map((c) => (
-            <button key={c.name} onClick={() => addNode(c.name)} style={{ display: 'block', marginBottom: 5 }}>
-              {c.name}
-            </button>
-          ))}
-          <div style={{ marginTop: 10 }}>
-            <input
-              type="text"
-              value={prompt}
-              onChange={(e) => setPrompt(e.target.value)}
-              placeholder="Prompt"
-            />
-            <button onClick={executeWorkflow} style={{ display: 'block', marginTop: 5 }}>
-              Execute
-            </button>
-            <button onClick={saveWorkflow} style={{ display: 'block', marginTop: 5 }}>
-              Save
-            </button>
-            <div style={{ marginTop: 5 }}>
-              <select
-                value={selectedWorkflow}
-                onChange={(e) => setSelectedWorkflow(e.target.value)}
-                style={{ width: '100%', marginBottom: 5 }}
-              >
-                <option value="">Select workflow</option>
-                {workflows.map((w) => (
-                  <option key={w} value={w}>
-                    {w}
-                  </option>
-                ))}
-              </select>
-              <button
-                onClick={() => selectedWorkflow && loadWorkflow(selectedWorkflow)}
-                style={{ display: 'block', marginTop: 0 }}
-              >
-                Load
-              </button>
-            </div>
-          </div>
-          {error && (
-            <div style={{ color: 'red', marginTop: 10 }}>{error}</div>
-          )}
-        </div>
-        <div style={{ flexGrow: 1, position: 'relative', display: 'flex' }}>
-          <div style={{ flexGrow: 1 }}>
-            <ReactFlow
-              nodes={nodes}
-              edges={edges}
-              onNodesChange={onNodesChange}
-              onEdgesChange={onEdgesChange}
-              onConnect={onConnect}
-              onNodeClick={(_, n) => setSelectedNodeId(n.id)}
-              nodeTypes={nodeTypes}
-              fitView
-            >
-              <Background />
-              <Controls />
-            </ReactFlow>
-            {result && (
-              <pre style={{ position: 'absolute', bottom: 0, left: 0, right: 0, maxHeight: 200, overflow: 'auto', background: '#eee', margin: 0 }}>
-                {result}
-              </pre>
-            )}
-          </div>
-          {selectedNodeId && (
-            <div style={{ width: 200, borderLeft: '1px solid #ccc', padding: 10 }}>
-              {components
-                .filter((c) => c.name === nodes.find((n) => n.id === selectedNodeId)?.type)
-                .map((c) => (
-                  <div key={c.name}>
-                    {Object.entries(c.settings || {}).map(([key, field]: any) => {
-                      const value =
-                        nodes.find((n) => n.id === selectedNodeId)?.data.params?.[key] ?? '';
-                      const inputProps = {
-                        'data-testid': `param-${key}`,
-                        value,
-                        onChange: (e: any) => {
-                          const v = field.type === 'number' ? Number(e.target.value) : field.type === 'boolean' ? e.target.checked : e.target.value;
-                          updateNodeParams(selectedNodeId, {
-                            ...(nodes.find((n) => n.id === selectedNodeId)?.data.params || {}),
-                            [key]: v,
-                          });
-                        },
-                      } as any;
-                      if (field.type === 'boolean') {
-                        return (
-                          <label key={key} style={{ display: 'block', marginBottom: 5 }}>
-                            {key}
-                            <input type="checkbox" checked={!!value} {...inputProps} />
-                          </label>
-                        );
-                      }
-                      return (
-                        <label key={key} style={{ display: 'block', marginBottom: 5 }}>
-                          {key}
-                          <input type="text" {...inputProps} />
-                        </label>
-                      );
-                    })}
-                  </div>
-                ))}
-                {!edges.some((e) => e.source === selectedNodeId) && (
-                  <label style={{ display: 'block', marginTop: 5 }}>
-                    Output Path
-                    <input
-                      type="text"
-                      data-testid="output-path"
-                      value={nodes.find((n) => n.id === selectedNodeId)?.data.outputPath || ''}
-                      onChange={(e) => updateNodeOutputPath(selectedNodeId, e.target.value)}
-                    />
-                  </label>
-                )}
-            </div>
-          )}
-        </div>
-      </div>
-    </ReactFlowProvider>
-  );
 }

--- a/packages/studio/src/utils/connectUtils.ts
+++ b/packages/studio/src/utils/connectUtils.ts
@@ -1,0 +1,29 @@
+export interface ComponentDef {
+    name: string;
+    inputs?: Record<string, { type?: string }>;
+    outputs?: Record<string, { type?: string }>;
+}
+
+export function canConnect(
+    params: { source?: string; target?: string },
+    nodes: Array<{ id: string; type?: string }>,
+    components: ComponentDef[],
+): boolean {
+    const sourceNode = nodes.find((n) => n.id === params.source);
+    const targetNode = nodes.find((n) => n.id === params.target);
+    if (!sourceNode || !targetNode) return true;
+    const sourceComp = components.find((c) => c.name === sourceNode.type);
+    const targetComp = components.find((c) => c.name === targetNode.type);
+    if (!sourceComp || !targetComp) return true;
+    const sourceType = firstType(sourceComp.outputs);
+    const targetType = firstType(targetComp.inputs);
+    if (!sourceType || !targetType) return true;
+    return sourceType === targetType;
+}
+
+function firstType(defs?: Record<string, { type?: string }>): string | null {
+    if (!defs) return null;
+    const key = Object.keys(defs)[0];
+    if (!key) return null;
+    return defs[key]?.type || null;
+}

--- a/packages/studio/tests/unit/App.test.tsx
+++ b/packages/studio/tests/unit/App.test.tsx
@@ -7,100 +7,97 @@ import React from 'react';
 import App from '../../src/App';
 
 class ResizeObserver {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
+    observe() {}
+    unobserve() {}
+    disconnect() {}
 }
 // @ts-ignore
 global.ResizeObserver = ResizeObserver;
 
 describe('App component', () => {
-  it('renders component names after fetch', async () => {
-    const components = [
-      { name: 'TextInput' },
-      { name: 'HTTPCall' },
-      { name: 'LLMPrompt' },
-      { name: 'CodeExec' },
-    ];
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => components,
-    }) as any;
+    it('renders component names after fetch', async () => {
+        const components = [{ name: 'TextInput' }, { name: 'HTTPCall' }, { name: 'LLMPrompt' }, { name: 'CodeExec' }];
+        global.fetch = vi.fn().mockImplementation((url: string) => {
+            if (url.includes('/components')) {
+                return Promise.resolve({ ok: true, json: async () => components }) as any;
+            }
+            return Promise.resolve({ ok: true, json: async () => [] }) as any;
+        }) as any;
 
-    render(<App />);
+        render(<App />);
 
-    for (const comp of components) {
-      expect(await screen.findByText(comp.name)).toBeTruthy();
-    }
-  });
+        for (const comp of components) {
+            expect(await screen.findByText(comp.name)).toBeTruthy();
+        }
+    });
 
-  it('allows editing node parameters', async () => {
-    const components = [
-      { name: 'TextInput', settings: { placeholder: { type: 'string' } } },
-    ];
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => components,
-    }) as any;
+    it('allows editing node parameters', async () => {
+        const components = [{ name: 'TextInput', settings: { placeholder: { type: 'string' } } }];
+        global.fetch = vi.fn().mockImplementation((url: string) => {
+            if (url.includes('/components')) {
+                return Promise.resolve({ ok: true, json: async () => components }) as any;
+            }
+            return Promise.resolve({ ok: true, json: async () => [] }) as any;
+        }) as any;
 
-    render(<App />);
+        render(<App />);
 
-    const btn = await screen.findByText('TextInput');
-    fireEvent.click(btn);
+        const btn = await screen.findByText('TextInput');
+        fireEvent.click(btn);
 
-    const [btnNode, nodeEl] = await screen.findAllByText('TextInput');
-    fireEvent.click(nodeEl);
+        const [btnNode, nodeEl] = await screen.findAllByText('TextInput');
+        fireEvent.click(nodeEl);
 
-    const input = await screen.findByTestId('param-placeholder');
-    fireEvent.change(input, { target: { value: 'hello' } });
+        const input = await screen.findByTestId('param-placeholder');
+        fireEvent.change(input, { target: { value: 'hello' } });
 
-    expect((input as HTMLInputElement).value).toBe('hello');
-    const pre = await screen.findByTestId('node-data');
-    expect(pre.textContent).toContain('hello');
-  });
+        expect((input as HTMLInputElement).value).toBe('hello');
+        const pre = await screen.findByTestId('node-data');
+        expect(pre.textContent).toContain('hello');
+    });
 
-  it('allows editing CodeExec parameters', async () => {
-    const components = [
-      { name: 'CodeExec', settings: { code: { type: 'string' } } },
-    ];
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => components,
-    }) as any;
+    it('allows editing CodeExec parameters', async () => {
+        const components = [{ name: 'CodeExec', settings: { code: { type: 'string' } } }];
+        global.fetch = vi.fn().mockImplementation((url: string) => {
+            if (url.includes('/components')) {
+                return Promise.resolve({ ok: true, json: async () => components }) as any;
+            }
+            return Promise.resolve({ ok: true, json: async () => [] }) as any;
+        }) as any;
 
-    render(<App />);
+        render(<App />);
 
-    const btn = await screen.findByText('CodeExec');
-    fireEvent.click(btn);
+        const btn = await screen.findByText('CodeExec');
+        fireEvent.click(btn);
 
-    const [, nodeEl] = await screen.findAllByText('CodeExec');
-    fireEvent.click(nodeEl);
+        const [, nodeEl] = await screen.findAllByText('CodeExec');
+        fireEvent.click(nodeEl);
 
-    const input = await screen.findByTestId('param-code');
-    fireEvent.change(input, { target: { value: 'console.log(1);' } });
+        const input = await screen.findByTestId('param-code');
+        fireEvent.change(input, { target: { value: 'console.log(1);' } });
 
-    expect((input as HTMLInputElement).value).toBe('console.log(1);');
-    const pre = await screen.findByTestId('node-data');
-    expect(pre.textContent).toContain('console.log(1);');
-  });
+        expect((input as HTMLInputElement).value).toBe('console.log(1);');
+        const pre = await screen.findByTestId('node-data');
+        expect(pre.textContent).toContain('console.log(1);');
+    });
 
-  it('shows output path for terminal nodes', async () => {
-    const components = [
-      { name: 'TextInput', settings: {} },
-    ];
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => components,
-    }) as any;
+    it('shows output path for terminal nodes', async () => {
+        const components = [{ name: 'TextInput', settings: {} }];
+        global.fetch = vi.fn().mockImplementation((url: string) => {
+            if (url.includes('/components')) {
+                return Promise.resolve({ ok: true, json: async () => components }) as any;
+            }
+            return Promise.resolve({ ok: true, json: async () => [] }) as any;
+        }) as any;
 
-    render(<App />);
+        render(<App />);
 
-    const btn = await screen.findByText('TextInput');
-    fireEvent.click(btn);
+        const btn = await screen.findByText('TextInput');
+        fireEvent.click(btn);
 
-    const [, nodeEl] = await screen.findAllByText('TextInput');
-    fireEvent.click(nodeEl);
+        const [, nodeEl] = await screen.findAllByText('TextInput');
+        fireEvent.click(nodeEl);
 
-    expect(await screen.findByTestId('output-path')).toBeTruthy();
-  });
+        expect(await screen.findByTestId('output-path')).toBeTruthy();
+    });
 });

--- a/packages/studio/tests/unit/connectUtils.test.ts
+++ b/packages/studio/tests/unit/connectUtils.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { canConnect } from '../../src/utils/connectUtils';
+
+const nodes = [
+    { id: '1', type: 'A' },
+    { id: '2', type: 'B' },
+];
+
+const components = [
+    { name: 'A', outputs: { out: { type: 'string' } } },
+    { name: 'B', inputs: { inp: { type: 'number' } } },
+];
+
+describe('canConnect', () => {
+    it('returns false for incompatible types', () => {
+        expect(canConnect({ source: '1', target: '2' }, nodes, components)).toBe(false);
+    });
+
+    it('returns true for matching types', () => {
+        const comps = [
+            { name: 'A', outputs: { out: { type: 'string' } } },
+            { name: 'B', inputs: { inp: { type: 'string' } } },
+        ];
+        expect(canConnect({ source: '1', target: '2' }, nodes, comps)).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- expose component outputs from the studio-server
- add connection validation utility
- enforce input/output type match on edge creation
- mock `/workflows` API in studio unit tests
- test connection compatibility logic

## Testing
- `pnpm test:run packages/studio/tests/unit/App.test.tsx packages/studio/tests/unit/connectUtils.test.ts`
- `pnpm test:run` *(fails: APIEndpoint tests require network resources)*

------
https://chatgpt.com/codex/tasks/task_e_68752db100a8832b95b75940b9b5f1e0