### PR TITLE
Update studio server README with environment vars

### DIFF
--- a/packages/studio-server/README.md
+++ b/packages/studio-server/README.md
@@ -4,9 +4,28 @@ This package exposes a lightweight Express server used by the SmythOS studio.
 
 ## Running
 
-Start the development server:
+### Environment Variables
+
+Before launching the server make sure the required API keys are available in the
+environment. At minimum you need an `OPENROUTER_API_KEY` so the runtime can make
+LLM requests. Workflows that use other connectors (for example Neon/PostgreSQL)
+require additional variables such as `NEON_HOST`, `NEON_USER`, `NEON_PASSWORD`
+and `NEON_DATABASE`.
+
+You can store these in a `.env` file:
 
 ```bash
+OPENROUTER_API_KEY=your-openrouter-key
+NEON_HOST=your-neon-host
+NEON_USER=your-neon-user
+NEON_PASSWORD=your-neon-password
+NEON_DATABASE=your-database
+```
+
+Export the variables before starting the server:
+
+```bash
+export $(grep -v '^#' .env | xargs)
 pnpm --filter @smythos/studio-server dev
 ```
 

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -13,6 +13,9 @@ Server. By default the server listens on `http://localhost:3010`.
 
 2. **Start the Studio Server**
 
+   Set `OPENROUTER_API_KEY` and any other required keys as described in the
+   [environment variables section](../studio-server/README.md#environment-variables).
+
    ```bash
    pnpm --filter @smythos/studio-server dev
    ```


### PR DESCRIPTION
## Summary
- document required OPENROUTER_API_KEY in studio-server README
- mention env var setup in Studio README

## Testing
- `pnpm test:run` *(fails: expected {} to be undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68753b6a6718832bb9c4fbae1ffdf2e9