### PR TITLE
Add GitCommit node and example workflow

### DIFF
--- a/packages/core/src/Components/GitCommit.class.ts
+++ b/packages/core/src/Components/GitCommit.class.ts
@@ -1,0 +1,31 @@
+import { Component } from './Component.class';
+import { IAgent as Agent } from '@sre/types/Agent.types';
+import Joi from 'joi';
+import { Git } from '@smythos/sdk';
+
+export class GitCommit extends Component {
+    protected configSchema = Joi.object({
+        repoPath: Joi.string().required().label('Repository Path'),
+        message: Joi.string().required().label('Commit Message'),
+    });
+
+    constructor() {
+        super();
+    }
+    init() {}
+
+    async process(input: any, config: any, agent: Agent) {
+        await super.process(input, config, agent);
+        const logger = this.createComponentLogger(agent, config);
+        try {
+            const repoPath = config.data.repoPath;
+            const message = config.data.message;
+            const git = Git.instance();
+            await git.commit(repoPath, message);
+            return { Success: true, _error: undefined, _debug: logger.output };
+        } catch (err: any) {
+            logger.error('Git commit failed', err?.message || err.toString());
+            return { Success: false, _error: err?.message || err.toString(), _debug: logger.output };
+        }
+    }
+}

--- a/packages/core/src/Components/index.ts
+++ b/packages/core/src/Components/index.ts
@@ -39,6 +39,7 @@ import { ServerlessCode } from './ServerlessCode.class';
 import { ImageGenerator } from './ImageGenerator.class'; // Legacy
 import { MCPClient } from './MCPClient.class';
 import { OpenAPI } from './OpenAPI.class';
+import { GitCommit } from './GitCommit.class';
 
 const components = {
     Component: new Component(),
@@ -85,6 +86,7 @@ const components = {
     ImageGenerator: new ImageGenerator(),
     MCPClient: new MCPClient(),
     OpenAPI: new OpenAPI(),
+    GitCommit: new GitCommit(),
 };
 
 export const ComponentInstances = components;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,6 +47,7 @@ export * from './Components/TavilyWebSearch.class';
 export * from './Components/VisionLLM.class';
 export * from './Components/WebSearch.class';
 export * from './Components/ZapierAction.class';
+export * from './Components/GitCommit.class';
 export * from './Core/AgentProcess.helper';
 export * from './Core/boot';
 export * from './Core/Connector.class';

--- a/packages/core/tests/unit/components/GitCommit.test.ts
+++ b/packages/core/tests/unit/components/GitCommit.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { GitCommit } from '../../../src/Components/GitCommit.class';
+import fs from 'fs';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { execSync } from 'child_process';
+
+function tempDir(prefix: string) {
+    return mkdtempSync(path.join(tmpdir(), prefix));
+}
+
+const agent: any = { id: 'agent', teamId: 'team', agentRuntime: { debug: false }, isKilled: () => false };
+
+describe('GitCommit Component', () => {
+    it('commits changes in a repository', async () => {
+        const repoDir = tempDir('gitcommit-');
+        execSync('git init', { cwd: repoDir });
+        fs.writeFileSync(path.join(repoDir, 'file.txt'), 'hello');
+        execSync('git add .', { cwd: repoDir });
+        execSync('git commit -m "init"', { cwd: repoDir });
+
+        fs.appendFileSync(path.join(repoDir, 'file.txt'), ' world');
+
+        const gitCommit = new GitCommit();
+        const config = { data: { repoPath: repoDir, message: 'update' }, id: '1' } as any;
+        const res = await gitCommit.process({}, config, agent);
+        expect(res._error).toBeUndefined();
+
+        const log = execSync('git -C ' + repoDir + ' log -1 --pretty=%B').toString().trim();
+        expect(log).toBe('update');
+    });
+});

--- a/packages/studio-server/README.md
+++ b/packages/studio-server/README.md
@@ -82,3 +82,15 @@ The `workflow` object must include a `version` and arrays of `components` and
   ]
 }
 ```
+
+## GitCommit Node Tutorial
+
+The server includes a `GitCommit` component for saving repository changes. The node takes two settings:
+
+- `repoPath` – path to the local Git repository
+- `message` – commit message
+
+When executed the server adds all modified files and creates a commit using the Git connector.
+
+A minimal workflow demonstrating the node can be found at `packages/studio-server/workflows/git-commit.smyth`. It clones a repository, appends text to a file and then commits the update.
+

--- a/packages/studio-server/workflows/git-commit.smyth
+++ b/packages/studio-server/workflows/git-commit.smyth
@@ -1,0 +1,13 @@
+{
+  "version": "1.0.0",
+  "components": [
+    { "id": "1", "name": "CodeExec", "data": { "code_body": "git clone https://github.com/smythos/test-repo.git repo" } },
+    { "id": "2", "name": "CodeExec", "data": { "code_body": "echo 'change' >> repo/README.md" } },
+    { "id": "3", "name": "GitCommit", "data": { "repoPath": "repo", "message": "update" } }
+  ],
+  "connections": [
+    { "sourceId": "1", "sourceIndex": 0, "targetId": "2", "targetIndex": 0 },
+    { "sourceId": "2", "sourceIndex": 0, "targetId": "3", "targetIndex": 0 }
+  ]
+}
+

--- a/packages/studio/src/App.tsx
+++ b/packages/studio/src/App.tsx
@@ -5,6 +5,7 @@ import TextInputNode from './nodes/TextInputNode';
 import HTTPCallNode from './nodes/HTTPCallNode';
 import LLMPromptNode from './nodes/LLMPromptNode';
 import CodeExecNode from './nodes/CodeExecNode';
+import GitCommitNode from './nodes/GitCommitNode';
 import { serializeWorkflow } from './utils/serializeWorkflow';
 import { deserializeWorkflow } from './utils/deserializeWorkflow';
 import 'reactflow/dist/style.css';
@@ -16,6 +17,7 @@ const nodeTypes = {
     HTTPCall: HTTPCallNode,
     LLMPrompt: LLMPromptNode,
     CodeExec: CodeExecNode,
+    GitCommit: GitCommitNode,
 };
 
 export default function App() {

--- a/packages/studio/src/nodes/GitCommitNode.tsx
+++ b/packages/studio/src/nodes/GitCommitNode.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Handle, Position } from 'reactflow';
+
+export default function GitCommitNode({ data }: any) {
+  return (
+    <div style={{ padding: 10, border: '1px solid #999', borderRadius: 4 }}>
+      <div>{data.label || 'GitCommit'}</div>
+      <pre data-testid="node-data">{JSON.stringify(data.params || {})}</pre>
+      <Handle type="source" position={Position.Right} />
+      <Handle type="target" position={Position.Left} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `GitCommit` component in core
- wire component into Studio UI
- provide example workflow demonstrating git operations
- document GitCommit node usage

## Testing
- `pnpm install`
- `npx -y vitest run` *(fails: TypeError, connection issues)*

------
https://chatgpt.com/codex/tasks/task_e_687548a718c0832bbe4d5373015b1cf1